### PR TITLE
Update NewsHour resources

### DIFF
--- a/app/views/special_collections/newshour.md
+++ b/app/views/special_collections/newshour.md
@@ -25,7 +25,6 @@ The *PBS NewsHour* Collection includes more than 13,500 episodes of *PBS NewsHou
 
 - [*PBS NewsHour* website](https://www.pbs.org/newshour/)
 - [History of *PBS NewsHour*](https://www.pbs.org/newshour/about/history)
-- [<em>Freedom Riders</em> Documentary website](http://www.pbs.org/wgbh/americanexperience/films/freedomriders/)
 - [“Gavel-to-Gavel": The Watergate Scandal and Public Television exhibit](http://americanarchive.org/exhibits/watergate)
 - [Preserving Public Broadcasting at 50 Years – Event at the Library of Congress (video recording)](https://www.youtube.com/watch?v=cHsceZqsH2M&t=)
 


### PR DESCRIPTION
Removes a resource link that has nothing to do with this collection and must have been leftover from using another collection as a template when creating this collection. 