### PR TITLE
1849 Processes Ampersands in PBCore and Displays on Front End

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,12 +20,11 @@ class Organization < Cmless
   end
 
   def self.clean_organization_names(organization_names)
-    names = []
-    organization_names.each do |name|
-     if name.include?("\n")
-      names << name.gsub!("\n", "").split.join(" ")
+    names = organization_names.each do |name|
+      if name.include?("\n")
+        name.delete!("\n").split.join(" ")
       else
-        names << name
+        name
       end
     end
     names
@@ -65,7 +64,7 @@ class Organization < Cmless
   end
 
   def facet_url
-    "/catalog?f[contributing_organizations][]=" + CGI::escape(facet)
+    "/catalog?f[contributing_organizations][]=" + CGI.escape(facet)
   end
 
   def short_name

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,14 +20,7 @@ class Organization < Cmless
   end
 
   def self.clean_organization_names(organization_names)
-    names = organization_names.each do |name|
-      if name.include?("\n")
-        name.delete!("\n").split.join(" ")
-      else
-        name
-      end
-    end
-    names
+    organization_names.map { |name| name.include?("\n") ? name.delete!("\n").split.join(" ") : name }
   end
 
   def id

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,6 +19,10 @@ class Organization < Cmless
     CGI.unescape(html.gsub(/<[^>]+>/, ''))
   end
 
+  def self.clean_organization_names(organization_names)
+    organization_names.map{ |name| name.gsub("\n", "").split.join(" ") if name.include?("\n") }
+  end
+
   def id
     @id ||= path
   end
@@ -52,13 +56,17 @@ class Organization < Cmless
     @city ||= Organization.clean(city_html)
   end
 
+  def facet_url
+    "/catalog?f[contributing_organizations][]=" + CGI::escape(facet)
+  end
+
   def short_name
     # this is really hacky, but the redcarpet gem for in cmless
     # for interpreting md was not recognizing the escaped ampersand
     # and a literal ampersand would display as a '&amp;'
     # fix should probably be in cmless with an update of redcarpet
     # but we're punting that for now.
-    @short_name ||= Organization.clean(short_name_html).gsub('&amp;', '&')
+    @short_name ||= Organization.clean(short_name_html).gsub("&amp;", "&")
   end
 
   def urls

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,7 +20,15 @@ class Organization < Cmless
   end
 
   def self.clean_organization_names(organization_names)
-    organization_names.map{ |name| name.gsub("\n", "").split.join(" ") if name.include?("\n") }
+    names = []
+    organization_names.each do |name|
+     if name.include?("\n")
+      names << name.gsub!("\n", "").split.join(" ")
+      else
+        names << name
+      end
+    end
+    names
   end
 
   def id

--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -187,7 +187,7 @@ class PBCorePresenter
     @img_width = img_dimensions[0]
   end
   def contributing_organization_names
-    @contributing_organization_names ||= xpaths('/*/pbcoreInstantiation/instantiationAnnotation[@annotationType="organization"]').uniq
+    @contributing_organization_names ||= Organization.clean_organization_names(xpaths('/*/pbcoreInstantiation/instantiationAnnotation[@annotationType="organization"]').uniq)
   end
   def contributing_organizations_facet
     @contributing_organizations_facet ||= contributing_organization_objects.map(&:facet) unless contributing_organization_objects.empty?

--- a/app/views/catalog/_contributing_organizations_facet.html.erb
+++ b/app/views/catalog/_contributing_organizations_facet.html.erb
@@ -2,7 +2,7 @@
   <%
     display_facet.items.group_by do |option|
       State.find_by_abbreviation(
-        option.value.match(/\((..)\)/)[1]
+        CGI.unescape(option.value).match(/\((..)\)/)[1]
       ).name
     end.sort.each do |state, options|
   %>
@@ -18,7 +18,7 @@
       options.each do |option|
     %>
       <li>
-        <%= render_facet_item(display_facet.name, OpenStruct.new(value: option.value)) %>
+        <%= render_facet_item(display_facet.name, OpenStruct.new(value: CGI.unescape(option.value))) %>
         <% if option.hits > 0 %>
           <span class="facet-count"><%= "#{option.hits}" %></span>
         <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -26,7 +26,7 @@
           <p><a href="<%= url %>"><%= url %></a></p>
         <% end %>
 
-        <a href="/catalog?f[contributing_organizations][]=<%= CGI::escape(@org.facet)%>" class="btn btn-default btn-sm">View All Records</a>
+        <a href="<%= @org.facet_url %>" class="btn btn-default btn-sm">View All Records</a>
 
       </div>
     </div>

--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -19,6 +19,7 @@ class Cleaner
     dirty_xml.gsub!("xsi:xmlns='http://www.w3.org/2001/XMLSchema-instance'",
                     "xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'")
     dirty_xml.gsub!("xmlns:xsi='xsi'", '')
+    dirty_xml.gsub!("&", '&amp;')
     doc = REXML::Document.new(dirty_xml)
 
     # pbcoreAssetType:

--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -19,7 +19,8 @@ class Cleaner
     dirty_xml.gsub!("xsi:xmlns='http://www.w3.org/2001/XMLSchema-instance'",
                     "xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'")
     dirty_xml.gsub!("xmlns:xsi='xsi'", '')
-    dirty_xml.gsub!("&", '&amp;')
+    # solo ampersands are an illegal character. encode it for REXMLr
+    dirty_xml.gsub!(/(&{1}\s)/, "&amp; ")
     doc = REXML::Document.new(dirty_xml)
 
     # pbcoreAssetType:

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -4,6 +4,13 @@ describe Organization do
   let(:wgbh) { Organization.find_by_pbcore_name('WGBH') }
   let(:loc) { Organization.find_by_pbcore_name('Library of Congress') }
 
+  # rubocop:disable Style/BlockDelimiters, Style/MultilineBlockLayout, Style/MultilineOperationIndentation, Style/BlockEndNewline
+
+  let(:dirty_organization_names) { ["The Walter J. Brown Media Archives & Peabody Awards Collection at the\n" +
+ "      University of Georgia"] }
+
+  # rubocop:enable Style/BlockDelimiters, Style/MultilineBlockLayout, Style/MultilineOperationIndentation  , Style/BlockEndNewline
+
   it 'contains expected data' do
     org = Organization.find_by_pbcore_name('WGBH')
     expect(org.pbcore_name).to eq('WGBH')
@@ -11,6 +18,7 @@ describe Organization do
     expect(org.id).to eq('1784.2')
     expect(org.city).to eq('Boston')
     expect(org.state).to eq('Massachusetts')
+    expect(org.facet_url).to eq("/catalog?f[contributing_organizations][]=WGBH+%28MA%29")
   end
 
   describe '.organizations' do
@@ -26,6 +34,13 @@ describe Organization do
   describe '.build_organization_names_display' do
     it 'returns an array of organization short names from an array of organization objects' do
       expect(Organization.build_organization_names_display([wgbh, loc])).to eq(['WGBH', 'Library of Congress'])
+    end
+  end
+
+  # This was an issue we were having with some pbcore.
+  describe '.clean_organization_names' do
+    it 'returns an array of organization short names without newlines or extra spaces' do
+      expect(Organization.clean_organization_names(dirty_organization_names)).to eq(["The Walter J. Brown Media Archives & Peabody Awards Collection at the University of Georgia"])
     end
   end
 end


### PR DESCRIPTION
We have organizations that use ampersands (&) in their names and this caused issues during ingest of the xml as well as in display on the front end due to using the name in URLs. This PR should make both of those things do-able for those organizations.