### PR TITLE
Adds CanonicalUrls

### DIFF
--- a/app/models/canonical_url.rb
+++ b/app/models/canonical_url.rb
@@ -1,0 +1,33 @@
+require 'yaml'
+require_relative '../../lib/aapb'
+require 'active_support'
+require 'active_support/core_ext'
+
+class CanonicalUrl
+  # Only a small number of records will have a canonical_url, so they are stored in a YAML file
+  # at config/canonical_urls/url_map.yml
+  attr_reader :id
+  attr_reader :url
+
+  def initialize(id)
+    raise "ID required to find canonical_url" unless id.present?
+    @id = id
+    @url = find_url(@id)
+  end
+
+  def find_url(id)
+    return nil unless ids_with_urls.include?(id)
+    canonical_urls.select { |url| url["id"] == id }.first["url"]
+  end
+
+  private
+
+  # Get all the canonical URLs from config
+  def canonical_urls
+    YAML.load_file(Rails.root + 'config/canonical_urls/url_map.yml')
+  end
+
+  def ids_with_urls
+    canonical_urls.map { |url| url["id"] }
+  end
+end

--- a/app/models/canonical_url.rb
+++ b/app/models/canonical_url.rb
@@ -24,7 +24,9 @@ class CanonicalUrl
 
   # Get all the canonical URLs from config
   def canonical_urls
-    YAML.load_file(Rails.root + 'config/canonical_urls/url_map.yml')
+    Rails.cache.fetch('canonical_urls') do
+      YAML.load_file(Rails.root + 'config/canonical_urls/url_map.yml')
+    end
   end
 
   def ids_with_urls

--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -17,6 +17,7 @@ require_relative '../../lib/caption_converter'
 require_relative 'transcript_file'
 require_relative 'caption_file'
 require_relative '../helpers/application_helper'
+require_relative 'canonical_url'
 
 class PBCorePresenter
   # rubocop:disable Style/EmptyLineBetweenDefs
@@ -225,6 +226,9 @@ class PBCorePresenter
     end
   rescue NoMatchError
     nil
+  end
+  def canonical_url
+    @canonical_url ||= CanonicalUrl.new(id).url
   end
   def access_level
     @access_level ||= begin

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -23,6 +23,10 @@
   <meta property="og:site_name" content="American Archive of Public Broadcasting"/>
   <meta property="og:description" content="<%= @pbcore.descriptions.join("\n") %>" />
 
+  <% if @pbcore.canonical_url.present? %>
+    <link rel="canonical" href="<%= @pbcore.canonical_url %>" />
+  <% end %>
+
   <!-- TODO: Doubt that these will be effective because we check the referer. -->
   <% if @pbcore.digitized? %>
     <% if @pbcore.video? %>

--- a/config/canonical_urls/url_map.yml
+++ b/config/canonical_urls/url_map.yml
@@ -1,0 +1,19 @@
+---
+-
+  id: cpb-aacip-50d685d2587
+  url: https://www.bloomberg.com/news/videos/2016-11-16/the-david-rubenstein-show-eric-schmidt?srnd=peer-to-peer
+-
+  id: cpb-aacip-fadada16564
+  url: https://www.bloomberg.com/news/videos/2016-11-23/the-david-rubenstein-show-indra-nooyi?srnd=peer-to-peer
+-
+  id: cpb-aacip-80ea7c79139
+  url: https://www.bloomberg.com/news/videos/2016-11-09/the-david-rubenstein-show-kenneth-chenault?srnd=peer-to-peer
+-
+  id: cpb-aacip-3fa8c28a26b
+  url: https://www.bloomberg.com/news/videos/2016-11-04/the-david-rubenstein-show-warren-buffett?srnd=peer-to-peer
+-
+  id: cpb-aacip-06a801715dd
+  url: https://www.bloomberg.com/news/videos/2016-10-26/the-david-rubenstein-show-lloyd-blankfein?srnd=peer-to-peer
+-
+  id: cpb-aacip-d65f34b524a
+  url: https://www.bloomberg.com/news/videos/2016-10-17/the-david-rubenstein-show-bill-gates?srnd=peer-to-peer

--- a/spec/models/canonical_url_spec.rb
+++ b/spec/models/canonical_url_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../../app/models/canonical_url'
+
+describe CanonicalUrl do
+  let(:id_with_url) { "cpb-aacip-50d685d2587" }
+  let(:id_without_url) { "cpb-aacip-12345" }
+
+  describe 'a record with a CanonicalUrl' do
+    let(:canonical_url) { described_class.new(id_with_url) }
+
+    it 'returns an id' do
+      expect(canonical_url.id).to eq(id_with_url)
+    end
+
+    it 'returns a URL' do
+      expect(canonical_url.url).to eq("https://www.bloomberg.com/news/videos/2016-11-16/the-david-rubenstein-show-eric-schmidt?srnd=peer-to-peer")
+    end
+  end
+
+  describe 'a record without a CanonicalUrl' do
+    let(:canonical_url) { described_class.new(id_without_url) }
+
+    it 'returns an id' do
+      expect(canonical_url.id).to eq(id_without_url)
+    end
+
+    it 'returns nil for a URL' do
+      expect(canonical_url.url).to eq(nil)
+    end
+  end
+
+  describe 'creating a CanonicalUrl with an empty ID' do
+    it 'raises an error' do
+      expect { CanonicalUrl.new("") }.to raise_error('ID required to find canonical_url')
+    end
+  end
+end


### PR DESCRIPTION
We have a small number of records where we'd like to add a canonical url to the head of the record's view. We decided to record these records in a YAML file and add to the view if there's a canonical url present.