### PR TITLE
Stub Rails.cache method correctly for each method that uses it 

### DIFF
--- a/app/models/canonical_url.rb
+++ b/app/models/canonical_url.rb
@@ -1,7 +1,4 @@
 require 'yaml'
-require_relative '../../lib/aapb'
-require 'active_support'
-require 'active_support/core_ext'
 
 class CanonicalUrl
   # Only a small number of records will have a canonical_url, so they are stored in a YAML file

--- a/app/models/validated_pb_core.rb
+++ b/app/models/validated_pb_core.rb
@@ -24,8 +24,8 @@ class ValidatedPBCore < PBCorePresenter
     # Warm the object and check for missing data, beyond what the schema enforces.
     # Don't like excluding :transcript_content here, but Rails.logger isn't available during ingest for CaptionConverter.parse_srt
     errors = []
-    # exclude transcript_src because dirty multi ID tests fail method validation
-    (PBCorePresenter.instance_methods(false) - [:to_solr, :transcript_content, :exhibits, :constructed_transcript_src]).each do |method|
+    # exclude transcript_src + canonical because dirty multi ID tests fail method validation
+    (PBCorePresenter.instance_methods(false) - [:to_solr, :transcript_content, :exhibits, :constructed_transcript_src, :canonical_url]).each do |method|
       begin
 
         send(method)

--- a/lib/rails_stub.rb
+++ b/lib/rails_stub.rb
@@ -15,11 +15,10 @@ module Rails
 
   unless Rails.respond_to?(:cache)
     def self.cache
-      return CacheStub.new()
+      CacheStub.new
     end
   end
 end
-
 
 class CacheStub
   def fetch(key)

--- a/lib/rails_stub.rb
+++ b/lib/rails_stub.rb
@@ -13,10 +13,20 @@ module Rails
     end
   end
 
-  # for geoip
   unless Rails.respond_to?(:cache)
     def self.cache
-      OpenStruct.new(fetch: MaxMindDB.new(Rails.root + 'config/GeoLite2-Country.mmdb'))
+      return CacheStub.new()
+    end
+  end
+end
+
+
+class CacheStub
+  def fetch(key)
+    if key == 'maxmind_db'
+      MaxMindDB.new(Rails.root + 'config/GeoLite2-Country.mmdb')
+    elsif key == 'canonical_urls'
+      YAML.load_file(Rails.root + 'config/canonical_urls/url_map.yml')
     end
   end
 end


### PR DESCRIPTION
This is necessary because new code was causing the ingest to crash when it tried to access `Rails.cache`

Defines the guts of the cache method in `rails_stub`

*Wow!*