### PR TITLE
1694 Conditionally hides nav search on special_collection searches

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -67,7 +67,7 @@
 
             <ul class="nav navbar-nav row">
               <!-- Nav Search -->
-              <% if !current_page?(controller: 'home', action: 'show') && !(current_page?(controller: 'catalog', action: 'index') && params.to_h['f'].try(:has_key?,'special_collection'))  %>
+              <% if !current_page?(controller: 'home', action: 'show') && !(current_page?(controller: 'catalog', action: 'index') && params['f'].try(:has_key?,'special_collections'))  %>
                   <li class="col-md-6 sec-nav-item"><%= render_search_bar %></li>
               <% end %>
               <li class="col-md-6 sec-nav-item"><%= link_to "FIX IT: A TRANSCRIPT GAME", "http://fixitplus.americanarchive.org/", class: "header-fixit", target: "_blank" %></li>


### PR DESCRIPTION
Fixes conditionally showing the navigation search box if there is or is not a special_collection on catalog#index.