### PR TITLE
Adds access level checks for embed URLs

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,6 +11,12 @@ class Ability
         (user.usa? && !user.bot? && (user.affirmed_tos? || user.authorized_referer?) && pbcore.public?)
     end
 
+    # Just like :play, only ignoring TOS check (it's in the embedded markup).
+    can :play_embedded, PBCorePresenter do |pbcore|
+      (user.onsite? && (pbcore.public? || pbcore.protected?)) ||
+        (user.usa? && !user.bot? && pbcore.public?)
+    end
+
     cannot :skip_tos, PBCorePresenter do |pbcore|
       # We handle international requests elsewhere and if pbcore is private
       # we do not need to show TOS because they won't get the media

--- a/app/views/embed/show.html.erb
+++ b/app/views/embed/show.html.erb
@@ -1,63 +1,77 @@
-<div class="row embed-player-row">
-  <div class="col-xs-12 col-sm-6 col-md-6 embed-player">
-    <section class="videocontent">
-    <%=
-      @pbcore.media_srcs.map do |media_src|
-        media = @pbcore.video? ? 'video' : 'audio'
-        content_tag(media,
-                    controls: true,
-                    "class" => "video-js vjs-default-skin vjs-fluid",
-                    "id" => "player_media",
-                    "aria-label" => "video player",
-                    oncontextmenu: 'return false;',
-                    preload: 'auto',
-                    crossorigin: 'with-credentials',
-                    :"data-setup" => '{}',
-                    poster: @pbcore.img_src) do %>
+<% if can? :play_embedded, @pbcore %>
+  <div class="row embed-player-row">
+    <div class="col-xs-12 col-sm-6 col-md-6 embed-player">
+      <section class="videocontent">
+      <%=
+        @pbcore.media_srcs.map do |media_src|
+          media = @pbcore.video? ? 'video' : 'audio'
+          content_tag(media,
+                      controls: true,
+                      "class" => "video-js vjs-default-skin vjs-fluid",
+                      "id" => "player_media",
+                      "aria-label" => "video player",
+                      oncontextmenu: 'return false;',
+                      preload: 'auto',
+                      crossorigin: 'with-credentials',
+                      :"data-setup" => '{}',
+                      poster: @pbcore.img_src) do %>
 
-          <source src="<%= media_src %>" type='<%= @pbcore.video? ? 'video/mp4' : 'audio/mp3' %>' />
+            <source src="<%= media_src %>" type='<%= @pbcore.video? ? 'video/mp4' : 'audio/mp3' %>' />
 
-          <% if @pbcore.captions_src %>
-            <track kind="captions" src="/captions/<%= @pbcore.id %>.vtt" srclang="en" label="English" default="default" />
-          <% end %>
-          <% if ChapterFile.file_present?(@pbcore.id) %>
-            <track kind="chapters" src=<%= ChapterFile.vtt_url(@pbcore.id) %> srclang="en" label="Chapters" />
-          <% end %>
-          <%
-        end
-      end.join().html_safe()
-    %>
-    </section>
-  </div>
-  <div class="col-xs-12 col-sm-6 col-md-6 embed-data">
-    <dl>
-      <dt>Title</dt>
-      <dd>
-        <a data-no-turbolink="true" href="/catalog/<%= @pbcore.id %>"><%= @pbcore.title %></a>
-      </dd>
-    </dl>
-    <dl>
-      <dt>Contributing Organization</dt>
-        <% @pbcore.contributing_organization_objects.each do |org| %>
-          <dd><a href='/participating-orgs/<%= url_encode(org.id) %>'><%= org.short_name %></a>
-            (<%= org.city %>, <%= org.state %>)</dd>
-        <% end %>
-    </dl>
-    <% unless @pbcore.asset_dates.empty? %>
+            <% if @pbcore.captions_src %>
+              <track kind="captions" src="/captions/<%= @pbcore.id %>.vtt" srclang="en" label="English" default="default" />
+            <% end %>
+            <% if ChapterFile.file_present?(@pbcore.id) %>
+              <track kind="chapters" src=<%= ChapterFile.vtt_url(@pbcore.id) %> srclang="en" label="Chapters" />
+            <% end %>
+            <%
+          end
+        end.join().html_safe()
+      %>
+      </section>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-6 embed-data">
       <dl>
-        <% @pbcore.asset_dates.each do |type,date| %>
-          <dt><%= type %></dt>
-          <dd><%= date %></dd>
-        <% end %>
+        <dt>Title</dt>
+        <dd>
+          <a data-no-turbolink="true" href="/catalog/<%= @pbcore.id %>"><%= @pbcore.title %></a>
+        </dd>
       </dl>
-    <% end %>
+      <dl>
+        <dt>Contributing Organization</dt>
+          <% @pbcore.contributing_organization_objects.each do |org| %>
+            <dd><a href='/participating-orgs/<%= url_encode(org.id) %>'><%= org.short_name %></a>
+              (<%= org.city %>, <%= org.state %>)</dd>
+          <% end %>
+      </dl>
+      <% unless @pbcore.asset_dates.empty? %>
+        <dl>
+          <% @pbcore.asset_dates.each do |type,date| %>
+            <dt><%= type %></dt>
+            <dd><%= date %></dd>
+          <% end %>
+        </dl>
+      <% end %>
 
-    <p>By accessing this content you agree to the AAPB's <a href="/legal/orr-rules">Online Reading Room Rules of Use</a>.</p>
+      <p>By accessing this content you agree to the AAPB's <a href="/legal/orr-rules">Online Reading Room Rules of Use</a>.</p>
 
-    <% if @is_clipped %>
-      <p>
-        This is a segment of a program available on the AAPB website. <a href="/catalog/<%= @pbcore.id %>">Access the full-length item.</a>
-      </p>
-    <% end %>
+      <% if @is_clipped %>
+        <p>
+          This is a segment of a program available on the AAPB website. <a href="/catalog/<%= @pbcore.id %>">Access the full-length item.</a>
+        </p>
+      <% end %>
+    </div>
   </div>
-</div>
+<% else %>
+  <% if @pbcore.public? && !current_user.usa? %>
+    Please note: This content is currently not available at your location.
+  <% elsif @pbcore.protected? %>
+    Please note: This content is only available at WGBH and the Library of Congress. For information about on location research, <a href="/on-location">click here</a>.
+  <% elsif @pbcore.private? %>
+    Please note: This content is only available at the Library of Congress. For information about on location research, <a href="/on-location">click here</a>.
+  <% elsif !@pbcore.digitized? && !@pbcore.contributing_organization_objects.empty? %>
+    This content has not been digitized. Please contact the contributing organization(s) listed below.
+  <% elsif !@pbcore.digitized? && @pbcore.contributing_organization_objects.empty? %>
+    This content has not been digitized.
+  <% end %>
+<% end %>

--- a/scripts/lib/pb_core_ingester.rb
+++ b/scripts/lib/pb_core_ingester.rb
@@ -20,12 +20,16 @@ class PBCoreIngester
     @success_count = 0
   end
 
-  def self.load_fixtures
+  def self.load_fixtures(*globs)
     # This is a test in its own right elsewhere.
     ingester = PBCoreIngester.new
     ingester.delete_all
-    Dir['spec/fixtures/pbcore/clean-*.xml'].each do |pbcore|
-      ingester.ingest(path: pbcore)
+    # If no globs were passed in, default to all "clean" PBCore fixtures.
+    globs << 'spec/fixtures/pbcore/clean-*.xml' if globs.empty?
+    # Get a list of all file paths from all the globs.
+    all_paths = globs.map { |glob| Dir[glob] }.flatten.uniq
+    all_paths.each do |path|
+      ingester.ingest(path: path)
     end
   end
 

--- a/spec/features/embed_spec.rb
+++ b/spec/features/embed_spec.rb
@@ -2,13 +2,39 @@ require 'rails_helper'
 require_relative '../../scripts/lib/pb_core_ingester'
 
 describe 'Embed' do
-  before(:all) do
-    PBCoreIngester.load_fixtures
+  before do
+    PBCoreIngester.load_fixtures(
+      # ID of this record is 'cpb-aacip_moving-image_public'
+      'spec/fixtures/pbcore/clean-moving-image-public.xml',
+      # ID of this record is 'cpb-aacip_moving-image_protected'
+      'spec/fixtures/pbcore/clean-moving-image-protected.xml',
+      # ID of this record is 'cpb-aacip_moving-image_private'
+      'spec/fixtures/pbcore/clean-moving-image-private.xml'
+    )
+
+    allow_any_instance_of(User).to receive(:usa?).and_return(true)
   end
 
-  it '/embed/[id] works' do
-    visit 'embed/cpb-aacip_111-21ghx7d6'
-    expect(page.status_code).to eq(200)
-    expect(page).to have_css('video')
+  context 'when record is public' do
+    before { visit 'embed/cpb-aacip_moving-image-public' }
+    it 'shows the video player' do
+      expect(page).to have_css('video')
+    end
+  end
+
+  context 'when record is protected' do
+    before { visit 'embed/cpb-aacip_moving-image-protected' }
+    it 'does not show the video player' do
+      expect(page).not_to have_css('video')
+      expect(page).to have_content "This content is only available at WGBH and the Library of Congress."
+    end
+  end
+
+  context 'when record is private' do
+    before { visit 'embed/cpb-aacip_moving-image-private' }
+    it 'does not show the video player' do
+      expect(page).not_to have_css('video')
+      expect(page).to have_content "This content is only available at the Library of Congress."
+    end
   end
 end

--- a/spec/fixtures/pbcore/clean-moving-image-private.xml
+++ b/spec/fixtures/pbcore/clean-moving-image-private.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<pbcoreDescriptionDocument xmlns="http://www.pbcore.org/PBCore/PBCoreNamespace.html" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd">
+  <pbcoreIdentifier source="NOLA Code">LOYE 000000 [SDBA]</pbcoreIdentifier>
+  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/moving-image-private</pbcoreIdentifier>
+  <pbcoreIdentifier source="Sony Ci">a-32-digit-hex</pbcoreIdentifier>
+  <pbcoreTitle titleType="Series">The Lost Year</pbcoreTitle>
+  <pbcoreDescription>
+    The "Lost Year" of 1958-59, is lesser known than the story that preceded it. But the Lost Year is a separate, equally significant historical episode. This documentary tells the untold story of the year following the 1957 crisis at Central High School.
+  </pbcoreDescription>
+  <pbcoreGenre source="AAPB Topical Genre" annotation="topic">Social Issues</pbcoreGenre>
+  <pbcoreGenre source="AAPB Topical Genre" annotation="topic">History</pbcoreGenre>
+  <pbcorePublisher>
+    <publisher>AETN</publisher>
+    <publisherRole>Distributor</publisherRole>
+  </pbcorePublisher>
+  <pbcoreInstantiation>
+    <instantiationIdentifier source="Arkansas Ed. TV"/>
+    <instantiationLocation>AETN Room 63</instantiationLocation>
+    <instantiationMediaType>Moving Image</instantiationMediaType>
+    <instantiationGenerations>Master</instantiationGenerations>
+    <instantiationTimeStart>00:00:00:00</instantiationTimeStart>
+    <instantiationDuration>00:59:34:00</instantiationDuration>
+    <instantiationColors>Color</instantiationColors>
+    <instantiationAnnotation annotationType="organization">Arkansas Educational TV Network (AETN)</instantiationAnnotation>
+    <instantiationExtension>
+      <extensionWrap>
+        <extensionElement>AACIP Record Nomination Status</extensionElement>
+        <extensionValue>Nominated/2nd Priority</extensionValue>
+        <extensionAuthorityUsed>AACIP</extensionAuthorityUsed>
+      </extensionWrap>
+    </instantiationExtension>
+  </pbcoreInstantiation>
+  <pbcoreAnnotation annotationType="Captions URL">
+    https://s3.amazonaws.com/americanarchive.org/captions/1a2b/1a2b.srt1.srt
+  </pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Private</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="last_modified">2013-06-01 16:19:40</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="organization">Arkansas Educational TV Network (AETN)</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-moving-image-protected.xml
+++ b/spec/fixtures/pbcore/clean-moving-image-protected.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<pbcoreDescriptionDocument xmlns="http://www.pbcore.org/PBCore/PBCoreNamespace.html" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd">
+  <pbcoreIdentifier source="NOLA Code">LOYE 000000 [SDBA]</pbcoreIdentifier>
+  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/moving-image-protected</pbcoreIdentifier>
+  <pbcoreIdentifier source="Sony Ci">a-32-digit-hex</pbcoreIdentifier>
+  <pbcoreTitle titleType="Series">The Lost Year</pbcoreTitle>
+  <pbcoreDescription>
+    The "Lost Year" of 1958-59, is lesser known than the story that preceded it. But the Lost Year is a separate, equally significant historical episode. This documentary tells the untold story of the year following the 1957 crisis at Central High School.
+  </pbcoreDescription>
+  <pbcoreGenre source="AAPB Topical Genre" annotation="topic">Social Issues</pbcoreGenre>
+  <pbcoreGenre source="AAPB Topical Genre" annotation="topic">History</pbcoreGenre>
+  <pbcorePublisher>
+    <publisher>AETN</publisher>
+    <publisherRole>Distributor</publisherRole>
+  </pbcorePublisher>
+  <pbcoreInstantiation>
+    <instantiationIdentifier source="Arkansas Ed. TV"/>
+    <instantiationLocation>AETN Room 63</instantiationLocation>
+    <instantiationMediaType>Moving Image</instantiationMediaType>
+    <instantiationGenerations>Master</instantiationGenerations>
+    <instantiationTimeStart>00:00:00:00</instantiationTimeStart>
+    <instantiationDuration>00:59:34:00</instantiationDuration>
+    <instantiationColors>Color</instantiationColors>
+    <instantiationAnnotation annotationType="organization">Arkansas Educational TV Network (AETN)</instantiationAnnotation>
+    <instantiationExtension>
+      <extensionWrap>
+        <extensionElement>AACIP Record Nomination Status</extensionElement>
+        <extensionValue>Nominated/2nd Priority</extensionValue>
+        <extensionAuthorityUsed>AACIP</extensionAuthorityUsed>
+      </extensionWrap>
+    </instantiationExtension>
+  </pbcoreInstantiation>
+  <pbcoreAnnotation annotationType="Captions URL">
+    https://s3.amazonaws.com/americanarchive.org/captions/1a2b/1a2b.srt1.srt
+  </pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">On Location</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="last_modified">2013-06-01 16:19:40</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="organization">Arkansas Educational TV Network (AETN)</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-moving-image-public.xml
+++ b/spec/fixtures/pbcore/clean-moving-image-public.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<pbcoreDescriptionDocument xmlns="http://www.pbcore.org/PBCore/PBCoreNamespace.html" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd">
+  <pbcoreIdentifier source="NOLA Code">LOYE 000000 [SDBA]</pbcoreIdentifier>
+  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/moving-image-public</pbcoreIdentifier>
+  <pbcoreIdentifier source="Sony Ci">a-32-digit-hex</pbcoreIdentifier>
+  <pbcoreTitle titleType="Series">The Lost Year</pbcoreTitle>
+  <pbcoreDescription>
+    The "Lost Year" of 1958-59, is lesser known than the story that preceded it. But the Lost Year is a separate, equally significant historical episode. This documentary tells the untold story of the year following the 1957 crisis at Central High School.
+  </pbcoreDescription>
+  <pbcoreGenre source="AAPB Topical Genre" annotation="topic">Social Issues</pbcoreGenre>
+  <pbcoreGenre source="AAPB Topical Genre" annotation="topic">History</pbcoreGenre>
+  <pbcorePublisher>
+    <publisher>AETN</publisher>
+    <publisherRole>Distributor</publisherRole>
+  </pbcorePublisher>
+  <pbcoreInstantiation>
+    <instantiationIdentifier source="Arkansas Ed. TV"/>
+    <instantiationLocation>AETN Room 63</instantiationLocation>
+    <instantiationMediaType>Moving Image</instantiationMediaType>
+    <instantiationGenerations>Master</instantiationGenerations>
+    <instantiationTimeStart>00:00:00:00</instantiationTimeStart>
+    <instantiationDuration>00:59:34:00</instantiationDuration>
+    <instantiationColors>Color</instantiationColors>
+    <instantiationAnnotation annotationType="organization">Arkansas Educational TV Network (AETN)</instantiationAnnotation>
+    <instantiationExtension>
+      <extensionWrap>
+        <extensionElement>AACIP Record Nomination Status</extensionElement>
+        <extensionValue>Nominated/2nd Priority</extensionValue>
+        <extensionAuthorityUsed>AACIP</extensionAuthorityUsed>
+      </extensionWrap>
+    </instantiationExtension>
+  </pbcoreInstantiation>
+  <pbcoreAnnotation annotationType="Captions URL">
+    https://s3.amazonaws.com/americanarchive.org/captions/1a2b/1a2b.srt1.srt
+  </pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="last_modified">2013-06-01 16:19:40</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="organization">Arkansas Educational TV Network (AETN)</pbcoreAnnotation>
+</pbcoreDescriptionDocument>


### PR DESCRIPTION
* Creates a new ability :play_embedded, which mimicks the :play ability, without
  the TOS checks.
* Adds logic to check :play_embed ability in the embed view.
* Adds specs for the embed feature for public, protected, and private records.
* Adds new fixtures (actually copies of existing fixtures) with the 3 different
  access levels.
* Enhances PdBCore.load_fixtures to accept a list of fixtures you want to load.
  Still defaults to all fixtures prefixed with clean-, but now you can be more
  selective.

Fixes #1989.