### PR TITLE
Get Correct Duration Value From Machine-Generated 'Proxy' Instantiation

### DIFF
--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -298,10 +298,16 @@ class PBCorePresenter
   def duration
     @duration ||= begin
       proxy_node = REXML::XPath.match(@doc, '/*/pbcoreInstantiation/instantiationGenerations[text()="Proxy"]/..').first
-      dur_node = REXML::XPath.match(proxy_node, 'instantiationEssenceTrack/essenceTrackDuration') if proxy_node
-      dur_node.first.text if dur_node
+      proxy_duration_node = REXML::XPath.match(proxy_node, 'instantiationEssenceTrack/essenceTrackDuration') if proxy_node
+      proxy_duration_node.first.text if proxy_duration_node
     rescue NoMatchError => e
-      nil
+
+      begin
+        any_duration_node = REXML::XPath.match(@doc, '/*/pbcoreInstantiation/instantiationEssenceTrack/essenceTrackDuration').first
+        any_duration_node.text if any_duration_node
+      rescue NoMatchError => e
+        nil
+      end
     end
   end
   def seconds

--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -297,15 +297,11 @@ class PBCorePresenter
   end
   def duration
     @duration ||= begin
-      xpath('/*/pbcoreInstantiation/instantiationEssenceTrack/essenceTrackDuration')
-    rescue
-
-      # old cases
-      begin
-        xpath('/*/pbcoreInstantiation/instantiationGenerations[text()="Proxy"]/../instantiationDuration')
-      rescue
-        xpaths('/*/pbcoreInstantiation/instantiationDuration').first
-      end
+      proxy_node = REXML::XPath.match(@doc, '/*/pbcoreInstantiation/instantiationGenerations[text()="Proxy"]/..').first
+      dur_node = REXML::XPath.match(proxy_node, 'instantiationEssenceTrack/essenceTrackDuration') if proxy_node
+      dur_node.first.text if dur_node
+    rescue NoMatchError => e
+      nil
     end
   end
   def seconds


### PR DESCRIPTION
Changes `PBCorePresenter#duration` to
-be able to return a duration value
-prefer the "Proxy" machine-generated duration value