### PR TITLE
Removes Feedback Link from Navigation Dropdown

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -44,7 +44,6 @@
                 <li><a href="/about-the-american-archive/advisory-committees">Advisory Committees</a></li>
                 <li><a href="/faq">FAQ</a></li>
                 <li><a href="/about-the-american-archive/newsletter">Newsletter Signup</a></li>
-                <li><a href="/about-the-american-archive/feedback">Feedback</a></li>
                 <li><a href="/contact-us">Contact Us</a></li>
               </ul>
             </li>


### PR DESCRIPTION
This was a broken link to a Feedback form that we're not implementing through this PR.