### PR TITLE
Preserve Substitution of / for _ on ingest for consistency with old id logic

### DIFF
--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -127,7 +127,8 @@ class PBCorePresenter
 
   def solr_matched_id
     @id ||= begin
-      guid_from_xml = xpath('/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]')
+      # need to turn '/' into '_' *on ingest* as well, for consistency with #original_id above
+      guid_from_xml = xpath('/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]').gsub('cpb-aacip/', 'cpb-aacip_')
 
       # check if xml guid is in database
       return guid_from_xml if verify_guid(guid_from_xml)
@@ -163,7 +164,8 @@ class PBCorePresenter
     @display_ids ||= ids.keep_if { |i| i[0] == 'AAPB ID' || i[0].downcase.include?('nola') }
   end
   def media_srcs
-    @media_srcs ||= (1..ci_ids.count).map { |part| "/media/#{id}?part=#{part}" }
+    # need original ID, because MediaController searches solr by id 
+    @media_srcs ||= (1..ci_ids.count).map { |part| "/media/#{original_id}?part=#{part}" }
   end
   CAPTIONS_ANNOTATION = 'Captions URL'.freeze
   def captions_src

--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -164,7 +164,7 @@ class PBCorePresenter
     @display_ids ||= ids.keep_if { |i| i[0] == 'AAPB ID' || i[0].downcase.include?('nola') }
   end
   def media_srcs
-    # need original ID, because MediaController searches solr by id 
+    # need original Id - medicontroller searches solr by id
     @media_srcs ||= (1..ci_ids.count).map { |part| "/media/#{original_id}?part=#{part}" }
   end
   CAPTIONS_ANNOTATION = 'Captions URL'.freeze

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -30,10 +30,10 @@
   <!-- TODO: Doubt that these will be effective because we check the referer. -->
   <% if @pbcore.digitized? %>
     <% if @pbcore.video? %>
-      <meta property="og:video" content="http://americanarchive.org/media/<%= @pbcore.id %>" />
+      <meta property="og:video" content="http://americanarchive.org/media/<%= @pbcore.original_id %>" />
     <% end %>
     <% if @pbcore.audio? %>
-      <meta property="og:audio" content="http://americanarchive.org/media/<%= @pbcore.id %>" />
+      <meta property="og:audio" content="http://americanarchive.org/media/<%= @pbcore.original_id %>" />
     <% end %>
   <% end %>
 <% end %>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -545,7 +545,7 @@ describe 'Validated and plain PBCore' do
           'playlist_group' => 'nixonimpeachmentday2',
           'playlist_order' => 1,
           # this is going to be the original id from the pbcore, because playlists do a bare solr search to look up playlist records
-          'playlist_next_id' => 'cpb-aacip/512-0r9m32nw1x',
+          'playlist_next_id' => 'cpb-aacip_512-0r9m32nw1x',
           'playlist_prev_id' => nil
         }
 
@@ -565,8 +565,8 @@ describe 'Validated and plain PBCore' do
         expected_attrs = {
           'playlist_group' => 'nixonimpeachmentday2',
           'playlist_order' => 2,
-          'playlist_next_id' => 'cpb-aacip/512-w66930pv96',
-          'playlist_prev_id' => 'cpb-aacip/512-gx44q7rk20'
+          'playlist_next_id' => 'cpb-aacip_512-w66930pv96',
+          'playlist_prev_id' => 'cpb-aacip_512-gx44q7rk20'
         }
 
         attrs = {
@@ -585,7 +585,7 @@ describe 'Validated and plain PBCore' do
           'playlist_group' => 'nixonimpeachmentday2',
           'playlist_order' => 3,
           'playlist_next_id' => nil,
-          'playlist_prev_id' => 'cpb-aacip/512-0r9m32nw1x'
+          'playlist_prev_id' => 'cpb-aacip_512-0r9m32nw1x'
         }
 
         attrs = {


### PR DESCRIPTION
New GUID normalization logic was taking whatever guid was in the xml and using that as `id` inside solr. Because of expectations elsewhere in AAPB that '/' guids have been transformed into '_' guids:

-the '/' guid was used on ingest
-MediaController later expected the guid to be a '_'

This is fixed by subbing the '/' to a '_' on ingest. Confirmed that production AAPB solr does not have any '/' guids in it.