### PR TITLE
1994 Transcripts No Timecode

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -191,18 +191,12 @@ class CatalogController < ApplicationController
     # the exhibit or special collection for additional display logic.
     @exhibit = exhibit_from_url
     @special_collection = special_collection_from_url
-
     # Cleans up user query for manipulation of caption text in the view.
     @query_for_captions = clean_query_for_snippet(params[:q]) if params[:q]
 
     if !params[:f] || !params[:f][:access_types]
-      base_query = params.except(:action, :controller).to_query
-      access = if current_user.onsite?
-                 PBCorePresenter::DIGITIZED_ACCESS
-               else
-                 PBCorePresenter::PUBLIC_ACCESS
-               end
-      redirect_to "/catalog?#{base_query}&f[access_types][]=#{access}"
+      # Sets Access Level
+      default_search_access(params)
     else
       super
     end
@@ -230,7 +224,6 @@ class CatalogController < ApplicationController
       fixed_matches = {}
       # value is unused because the presence of the guid as a key is what indicates the match
       matched_in_text_field.map { |k, _v| fixed_matches[normalize_guid(k)] = {} }
-
       @snippets = {}
 
       @document_list.each do |solr_doc|
@@ -250,14 +243,13 @@ class CatalogController < ApplicationController
             @snippets[this_id][:transcript] = @transcript_snippet.highlight_snippet
             @snippets[this_id][:transcript_timecode_url] = @transcript_snippet.url_at_timecode
           elsif transcript_file.file_type == TranscriptFile::TEXT_FILE
-            @snippets[this_id][:transcript] = snippet_from_query(@query_for_captions, transcript_file.plaintext , 250, ' ')
+            @snippets[this_id][:transcript] = snippet_from_query(@query_for_captions, transcript_file.plaintext, 250, ' ')
           end
         elsif solr_doc.caption? && !@query_for_captions.nil?
           text = CaptionFile.new(solr_doc.captions_src).text
           @snippets[this_id][:caption] = snippet_from_query(@query_for_captions, text, 250, '.')
         end
       end
-
     end
   end
 
@@ -333,6 +325,16 @@ class CatalogController < ApplicationController
   end
 
   private
+
+  def default_search_access(params)
+    base_query = params.except(:action, :controller).to_query
+    access = if current_user.onsite?
+               PBCorePresenter::DIGITIZED_ACCESS
+             else
+               PBCorePresenter::PUBLIC_ACCESS
+             end
+    redirect_to "/catalog?#{base_query}&f[access_types][]=#{access}"
+  end
 
   def exhibit_from_url
     # Despite 'exhibit' field being multi-valued in solrconfig.xml, we're only

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -243,9 +243,15 @@ class CatalogController < ApplicationController
 
         # check for transcript/caption anno
         if solr_doc.transcript? && !@query_for_captions.nil?
-          @transcript_snippet = SnippetHelper::TranscriptSnippet.new('transcript' => TranscriptFile.new(solr_doc.transcript_src), 'id' => this_id, 'query' => @query_for_captions)
-          @snippets[this_id][:transcript] = @transcript_snippet.highlight_snippet
-          @snippets[this_id][:transcript_timecode_url] = @transcript_snippet.url_at_timecode
+          transcript_file = TranscriptFile.new(solr_doc.transcript_src)
+
+          if transcript_file.file_type == TranscriptFile::JSON_FILE
+            @transcript_snippet = SnippetHelper::TranscriptSnippet.new('transcript' => transcript_file, 'id' => this_id, 'query' => @query_for_captions)
+            @snippets[this_id][:transcript] = @transcript_snippet.highlight_snippet
+            @snippets[this_id][:transcript_timecode_url] = @transcript_snippet.url_at_timecode
+          elsif transcript_file.file_type == TranscriptFile::TEXT_FILE
+            @snippets[this_id][:transcript] = snippet_from_query(@query_for_captions, transcript_file.plaintext , 250, ' ')
+          end
         elsif solr_doc.caption? && !@query_for_captions.nil?
           text = CaptionFile.new(solr_doc.captions_src).text
           @snippets[this_id][:caption] = snippet_from_query(@query_for_captions, text, 250, '.')

--- a/app/helpers/snippet_helper.rb
+++ b/app/helpers/snippet_helper.rb
@@ -149,6 +149,7 @@ module SnippetHelper
   def process_single_query_terms(query, text, snippet_length)
     text_dictionary = text.gsub(/[[:punct:]]/, '').split
     intersection = query & text_dictionary
+
     return nil unless intersection && intersection.present?
     intersection_index = text.index(/\b(?:#{intersection[0]})\b/)
     start = if intersection_index && (intersection_index - snippet_length) > 0
@@ -156,6 +157,7 @@ module SnippetHelper
             else
               0
             end
+
     '...' + text[start..-1].to_s + '...'
   end
 

--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -19,6 +19,7 @@ require_relative 'transcript_file'
 require_relative 'caption_file'
 require_relative '../helpers/application_helper'
 require_relative 'canonical_url'
+require_relative '../helpers/id_helper'
 
 class PBCorePresenter
   # rubocop:disable Style/EmptyLineBetweenDefs

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -50,13 +50,18 @@
 
             <% if @snippets[pbcore.id][:transcript] %>
               <span class="index-data-title">From Transcript</span>:
-              <p style="margin-top: 0;"><%= @snippets[pbcore.id][:transcript] %> <a href="<%= @snippets[pbcore.id][:transcript_timecode_url] %>">
-              <%  if pbcore.media_type == 'Moving Image' %>
-                <button type="button" class="btn btn-default snippet-link">Watch from here</button>
-              <% else %>
-                <button type="button" class="btn btn-default snippet-link">Listen from here</button>
-              <% end %>
-              </a></p>
+              <p style="margin-top: 0;"><%= @snippets[pbcore.id][:transcript] %>
+
+                <% if @snippets[pbcore.id][:transcript_timecode_url] %>
+                  <a href="<%= @snippets[pbcore.id][:transcript_timecode_url] %>">
+                  <%  if pbcore.media_type == 'Moving Image' %>
+                    <button type="button" class="btn btn-default snippet-link">Watch from here</button>
+                  <% else %>
+                    <button type="button" class="btn btn-default snippet-link">Listen from here</button>
+                  <% end %>
+                  </a>
+                <% end %>
+              </p>
             <% end %>
 
           </article>


### PR DESCRIPTION
We have text only transcripts from Newshour that were lost in catalog#index when we started to link to timecodes in media based on search params found in the time-coded transcripts. This adds support for transcripts with no timecodes.