### PR TITLE
Fixes canned topical searches from homepage

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -13,17 +13,17 @@ class SearchBuilder < Blacklight::SearchBuilder
     title_queries = query.scan(/titles:"[^"]*"{1}/)
     # remove from rest of query
     query = query.gsub(/titles:"[^"]*"{1}/, '') if title_queries.present?
-
     exact_clauses = query.scan(/"[^"]*"/).map { |clause| exactquery(clause.delete(%("))) }
 
     if exact_clauses.present?
       clean_query = query.gsub(/"[^"]*"/, '')
-      solr_parameters[:q] = %(#{exact_clauses.join(' ')}#{clean_query})
+      clean_query = clean_query.split(' OR ').compact.join(' OR ')
+      solr_parameters[:q] = %(#{exact_clauses.join(' ')} #{clean_query})
 
       # readd title queries back in if necessary
       solr_parameters[:q] += %( #{title_queries.join(' ')}) if title_queries.present?
     end
-    
+
     solr_parameters
   end
 
@@ -90,7 +90,7 @@ class SearchBuilder < Blacklight::SearchBuilder
                     genres_unstemmed
                     topics_unstemmed
                   )
-    %(+(#{fieldnames.map { |fieldname| %(#{fieldname}:"#{string}") }.join(' OR ')}))
+    %((#{fieldnames.map { |fieldname| %(#{fieldname}:"#{string}") }.join(' OR ')}))
   end
 
 

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -392,6 +392,14 @@ describe 'Catalog' do
         end
       end
     end
+
+    context 'quoted phrases in "OR" search', :focus do
+      let(:query_str) { 'q="Film and Television" OR "Event Coverage"' }
+      before { visit "/catalog?#{query_str}&f[access_types][]=all" }
+      it 'returns only records matching the phrase exactly (no stemming)' do
+        expect_count(2)
+      end
+    end
   end
 
   describe '.pbcore' do


### PR DESCRIPTION
Problem comes in SearchBuilder#apply_quote_handler where parsing of double quoted search phrases
was not getting re-added to the query after being modified to search unstemmed fields.

The process of mutating Solr's 'q' param non-idempotently is inherently problematic, and
attempts to do so for all possible cases in an idempotent way will take some more thinking.