### PR TITLE
Fixes quoted phrase searches, again

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -17,7 +17,9 @@ class SearchBuilder < Blacklight::SearchBuilder
 
     if exact_clauses.present?
       clean_query = query.gsub(/"[^"]*"/, '')
-      clean_query = clean_query.split(' OR ').compact.join(' OR ')
+      clean_query = clean_query.split(' OR ').
+                                select{ |term| term.present? }.
+                                join(' OR ')
       solr_parameters[:q] = %(#{exact_clauses.join(' ')} #{clean_query})
 
       # readd title queries back in if necessary

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -394,10 +394,27 @@ describe 'Catalog' do
     end
 
     context 'quoted phrases in "OR" search', :focus do
-      let(:query_str) { 'q="Film and Television" OR "Event Coverage"' }
-      before { visit "/catalog?#{query_str}&f[access_types][]=all" }
-      it 'returns only records matching the phrase exactly (no stemming)' do
-        expect_count(2)
+      let(:quoted_phrases) { '"Film and Television" OR "Event Coverage"' }
+
+      context ', with quoted phrase at the beginning' do
+        before { visit "/catalog?q=#{quoted_phrases}+OR+blergifoo&f[access_types][]=all" }
+        it 'returns only records matching the phrase exactly (no stemming)' do
+          expect_count(2)
+        end
+      end
+
+      context ', with quoted phrase at the end' do
+        before { visit "/catalog?q=blergifoo+OR+#{quoted_phrases}&f[access_types][]=all" }
+        it 'returns only records matching the phrase exactly (no stemming)' do
+          expect_count(2)
+        end
+      end
+
+      context ', with quoted phrase in the middle' do
+        before { visit "/catalog?q=blergifoo+OR+#{quoted_phrases}+OR+blergifoo&f[access_types][]=all" }
+        it 'returns only records matching the phrase exactly (no stemming)' do
+          expect_count(2)
+        end
       end
     end
   end


### PR DESCRIPTION
There was an error in how the OR operands were getting recombined.

Also adds tests for quoted searches at beginning, at the end, and in the middle
of the original search query URL param.