### PR TITLE
VJS Exhibit Gallery Player Fixes

### DIFF
--- a/app/assets/stylesheets/globals/videojs.css.scss
+++ b/app/assets/stylesheets/globals/videojs.css.scss
@@ -21,6 +21,13 @@ span.vjs-current-time-display {
 .videojs div.vjs-time-divide {
   display: none !important;
 }
+
+
+/*disallow play/pause clicks on whole video element*/
+.vjs-tech {
+  pointer-events: none;
+}
+
 /*
 div.vjs-duration {
   display: none !important;

--- a/app/views/exhibits/_gallery.html.erb
+++ b/app/views/exhibits/_gallery.html.erb
@@ -161,11 +161,12 @@
     </div>
   </div>
 
-  <link href="http://vjs.zencdn.net/5.11.7/video-js.css" rel="stylesheet">
-  <script src="http://vjs.zencdn.net/5.11.7/video.js"></script>
-  <!-- video-js support for IE 8 -->
-  <script src="http://vjs.zencdn.net/ie8/1.1.2/videojs-ie8.min.js"></script>
-  <!-- Need VideoJS for our player.js file -->
+
+  <link href="https://vjs.zencdn.net/7.2.3/video-js.css" rel="stylesheet">
+  <script src="https://vjs.zencdn.net/7.2.3/video.js" ></script>
+  <!-- If you'd like to support IE8 (for Video.js versions prior to v7) -->
+  <script src="https://vjs.zencdn.net/ie8/ie8-version/videojs-ie8.min.js" ></script>
+    <!-- Need VideoJS for our player.js file -->
   <%= javascript_include_tag 'player' %>
 
   <script type="text/javascript">

--- a/app/views/exhibits/black-power.md
+++ b/app/views/exhibits/black-power.md
@@ -51,7 +51,7 @@ A few of these programs such as *Black Journal* (NET, New York) and *Soul!* (WND
 
 Since Stokely Carmichael had called for Black Power during his June 16, 1966, speech in Greenwood, Mississippi, the concept of Black Power was largely depicted by mainstream media as radical and potentially dangerous. [<sup>6</sup>](/exhibits/black-power/notes#6) African American produced public and cultural affairs programming, however, gave voice to the changing political tide evident in the Black Power ethos of the time. These shows expressed a variety of political viewpoints and were often not tethered to the FCC’s “Fairness Doctrine” that required television shows to exhibit a balanced view on controversial topics. The producers of these shows, such as *Black Journal* producer William Greaves and Ellis Haizlip of *Soul!*, believed that for far too long television had excluded Black viewpoints all together. Black produced public affairs programs allowed for multiple perspectives on strategies for Black empowerment to be seen across national airwaves for the very first time in US history.
 
-#### Next: [Black Journal](/exhibits/Black-Power/Televising-Black-Politics/Black-Journal)
+#### Next: [Black Journal](/exhibits/Black-Power/Televising-Black-Politics/black-journal)
 
 ## Cover
 <table class="exhibit-image">

--- a/app/views/exhibits/black-power/notes.md
+++ b/app/views/exhibits/black-power/notes.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-### Bibliography
+### 
 
 - Acham, Christine. *Revolution Televised: Prime Time and the Struggle for Black Power*. Minneapolis: University of Minnesota Press, 2004.
 

--- a/app/views/exhibits/show.html.erb
+++ b/app/views/exhibits/show.html.erb
@@ -15,9 +15,9 @@
     <li><%= @exhibit.title %></li>
   </ol>
 
-  <div class="row" style="margin-bottom: 4%;">
+  <div class="row" style="margin-bottom: 4%; margin-top: 2%;">
 
-    <% if @exhibit.path.ends_with?('timeline') %>
+    <% if @exhibit.path.ends_with?('timeline') || @exhibit.path.ends_with?('notes') %>
 
       <div class="col-md-12">
         <div id="exhibit-text-container" class="row exhibit-text" style="margin-left: 0;margin-right: 0;margin-top: 0;margin-bottom: 4%;">


### PR DESCRIPTION
-Upgrade VJS version for exhibit gallery player
-Only play/pause video by clicking play button
-Hide gallery section on exhibit 'notes' page