### PR TITLE
Updates PBCore gem to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,5 @@ gem 'nokogiri', '~> 1.10.4'
 # its back
 gem 'bigdecimal'
 gem 'httparty'
+
+gem 'pbcore', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,10 @@ GEM
     diff-lcs (1.3)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    faker (1.9.6)
+      i18n (>= 0.7)
     fastimage (2.1.7)
     ffi (1.12.2)
     globalid (0.4.2)
@@ -191,6 +195,11 @@ GEM
     passenger (6.0.4)
       rack
       rake (>= 0.8.1)
+    pbcore (0.2.0)
+      factory_bot (~> 4.11)
+      faker (~> 1.9)
+      nokogiri (~> 1.10)
+      sax-machine (~> 1.3)
     powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -282,6 +291,7 @@ GEM
       tilt (>= 1.1, < 3)
     sassc (2.2.1)
       ffi (~> 1.9)
+    sax-machine (1.3.2)
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -351,6 +361,7 @@ DEPENDENCIES
   maxminddb
   nokogiri (~> 1.10.4)
   passenger
+  pbcore (~> 0.2.0)
   pry
   pry-nav
   rack-cors (~> 1.0.5)


### PR DESCRIPTION
This PBCore gem release completes all the models (except for pbcorePart) and provides factories with Faker data for all PBCore elements, including pbcoreDescriptionDocument, pbcoreInstantiationDocument, and pbcoreInstantiation, which are all "complete" (i.e. all possible attributes have value, and contains either a value or complete instances of children, whichever is applicable).