### PR TITLE
Cdata Newline Fix

### DIFF
--- a/app/models/xml_backed.rb
+++ b/app/models/xml_backed.rb
@@ -27,7 +27,7 @@ module XmlBacked
   end
 
   def xpaths(xpath)
-    # Need to process it cdata children if they're present
+    # Need to process cdata children if they're present
     REXML::XPath.match(@doc, xpath).map { |node| cdata_present?(node) ? node.cdatas.first : XmlBacked.text_from(node) }
   end
 
@@ -36,7 +36,7 @@ module XmlBacked
   end
 
   def cdata_present?(node)
-    node.respond_to?('cdatas') && !node.cdatas.empty? ? true : false
+    node.respond_to?('cdatas') && !node.cdatas.empty?
   end
 
   def pairs_by_type(element_xpath, attribute_xpath)

--- a/app/models/xml_backed.rb
+++ b/app/models/xml_backed.rb
@@ -27,11 +27,16 @@ module XmlBacked
   end
 
   def xpaths(xpath)
-    REXML::XPath.match(@doc, xpath).map { |node| XmlBacked.text_from(node) }
+    # Need to process it as cdata children if they're present
+    REXML::XPath.match(@doc, xpath).map { |node| cdata_present?(node) ? node.cdatas.first : XmlBacked.text_from(node) }
   end
 
   def self.text_from(node)
     ((node.respond_to?('text') ? node.text : node.value) || '').strip
+  end
+
+  def cdata_present?(node)
+    node.respond_to?('cdatas') && node.cdatas.length > 0 ? true : false
   end
 
   def pairs_by_type(element_xpath, attribute_xpath)

--- a/app/models/xml_backed.rb
+++ b/app/models/xml_backed.rb
@@ -27,7 +27,7 @@ module XmlBacked
   end
 
   def xpaths(xpath)
-    # Need to process it as cdata children if they're present
+    # Need to process it cdata children if they're present
     REXML::XPath.match(@doc, xpath).map { |node| cdata_present?(node) ? node.cdatas.first : XmlBacked.text_from(node) }
   end
 
@@ -36,7 +36,7 @@ module XmlBacked
   end
 
   def cdata_present?(node)
-    node.respond_to?('cdatas') && node.cdatas.length > 0 ? true : false
+    node.respond_to?('cdatas') && !node.cdatas.empty? ? true : false
   end
 
   def pairs_by_type(element_xpath, attribute_xpath)


### PR DESCRIPTION
Rights statement was coming back empty from the PBCorePresenter. When cdata is in the REXML node, if there's a newline before the cdata the REXL text method returns the empty string before the cdata. This checks for cdata and returns it if present.