### PR TITLE
Fix &amp; displaying in citations 

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -94,7 +94,7 @@ class Organization < Cmless
   end
 
   def self.build_organization_names_display(organizations)
-    organizations.map { |org| org.short_name_html.gsub(/<[^>]*>/, '') }
+    organizations.map { |org| org.short_name }
   end
 
   def to_a

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,5 @@
-require_relative '../../lib/markdowner'
 require_relative '../../lib/aapb'
+require_relative '../../lib/markdowner'
 require_relative 'state'
 require 'yaml'
 require 'cgi'
@@ -94,7 +94,7 @@ class Organization < Cmless
   end
 
   def self.build_organization_names_display(organizations)
-    organizations.map { |org| org.short_name }
+    organizations.map(&:short_name)
   end
 
   def to_a

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -187,7 +187,6 @@
 
     <div class="catalog-alert">
 
-      Good gracious & is bodacious
       <div class="catalog-alert-text">
         <% @pbcore.ids.first[1].tap do |id| %>
           If you have more information about this item than what is given here, we want to know! <a href="mailto:aapb_notifications@wgbh.org">Contact us</a>, indicating the AAPB ID (<%= id %>).

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -190,7 +190,7 @@
       Good gracious & is bodacious
       <div class="catalog-alert-text">
         <% @pbcore.ids.first[1].tap do |id| %>
-          If you have more information about this item than what is given here, we want to know! <a href="mailto:aapb_notifications@wgbh.org">Contact us</a>, indicating the AAPB ID (<%= id + '&' %>).
+          If you have more information about this item than what is given here, we want to know! <a href="mailto:aapb_notifications@wgbh.org">Contact us</a>, indicating the AAPB ID (<%= id %>).
         <% end %>
       </div>
     </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -186,9 +186,11 @@
     <% end %>
 
     <div class="catalog-alert">
+
+      Good gracious & is bodacious
       <div class="catalog-alert-text">
         <% @pbcore.ids.first[1].tap do |id| %>
-          If you have more information about this item than what is given here, we want to know! <a href="mailto:aapb_notifications@wgbh.org">Contact us</a>, indicating the AAPB ID (<%= id %>).
+          If you have more information about this item than what is given here, we want to know! <a href="mailto:aapb_notifications@wgbh.org">Contact us</a>, indicating the AAPB ID (<%= id + '&' %>).
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Wrong method was used for printing out short name for contributing organizations, needed to explicitly gsub `&amp;` into `&` (as in `Organization#short_name`)