### PR TITLE
Updates Arkansas Public Television Org Page

### DIFF
--- a/app/views/organizations/md/1708.md
+++ b/app/views/organizations/md/1708.md
@@ -2,7 +2,7 @@
 
 ## Short name
 
-Arkansas Educational TV Network
+Arkansas Public Television
 
 ## State
 
@@ -14,7 +14,7 @@ Conway
 
 ## Logo
 
-
+arkansas\_pt\_logo.png
 
 ## Url
 
@@ -22,7 +22,7 @@ http://www.aetn.org/
 
 ## About
 
-
+Arkansas PBS is Arkansas’s only statewide public media network, which enhances lives by providing lifelong learning opportunities for people from all walks of life. Arkansas PBS delivers daily, essential, local, award-winning productions and classic, trusted PBS programs aimed at sharing Arkansas and the world with viewers through multiple digital platforms, including on-demand services and YouTube TV, and the distinct channels Arkansas PBS, Arkansas PBS Create, Arkansas PBS KIDS, Arkansas PBS WORLD and Arkansas PBS AIRS on SAP. Learn more at myarkansaspbs.org.
 
 ## Productions
 


### PR DESCRIPTION
This changes the name, adds a logo, and updates the text for the Arkansas Public Television org page. Because of the name change, this PR should not be released until we're ready to reindex all of the org's records.

Closes #2169 