### PR TITLE
ThePBCoreCorrector Update

### DIFF
--- a/scripts/lib/downloader.rb
+++ b/scripts/lib/downloader.rb
@@ -127,17 +127,24 @@ class Downloader
 
       content = if @options[:is_just_reindex]
                   $LOG.info("Query solr for #{id}")
+                  # Check to see if the doc is on AAPB SOLR
                   # TODO: hostname and corename from config?
-                  Solr.instance.connect
-                      .get('select', params: {
-                             qt: 'document', id: id
-                           })['response']['docs'][0]['xml']
+                  results = Solr.instance.connect.get('select', params: { qt: 'document', id: id })['response']['docs']
+
+                  if results.length > 0
+                    results[0]['xml']
+                  else
+                    # Set content to nil if nothing found in SOLR
+                    $LOG.info("SOLR Query is nil. Skipping ID: #{id}")
+                    nil
+                  end
                 else
                   url = "https://ams.americanarchive.org/xml/pbcore/key/#{KEY}/guid/#{short_id}"
                   $LOG.info("Downloading #{url}")
                   http_get(url)
       end
-      Zipper.write("#{short_id}.pbcore", content)
+      # Only write content that we actually find
+      Zipper.write("#{short_id}.pbcore", content) unless content.nil?
     end
   end
 

--- a/scripts/lib/downloader.rb
+++ b/scripts/lib/downloader.rb
@@ -131,12 +131,13 @@ class Downloader
                   # TODO: hostname and corename from config?
                   results = Solr.instance.connect.get('select', params: { qt: 'document', id: id })['response']['docs']
 
-                  if results.length > 0
-                    results[0]['xml']
-                  else
+                  if results.empty?
                     # Set content to nil if nothing found in SOLR
                     $LOG.info("SOLR Query is nil. Skipping ID: #{id}")
                     nil
+                  else
+                    # Return the XML
+                    results[0]['xml']
                   end
                 else
                   url = "https://ams.americanarchive.org/xml/pbcore/key/#{KEY}/guid/#{short_id}"

--- a/scripts/the_pbcore_corrector.rb
+++ b/scripts/the_pbcore_corrector.rb
@@ -9,10 +9,10 @@ class ThePBCoreCorrector
   TITLE_TYPES = ['series', 'program', 'episode', 'episode number', 'segment', 'clip', 'promo', 'raw footage'].freeze
   DESCRIPTION_TYPES = ['series', 'program', 'episode', 'segment', 'clip', 'promo', 'raw footage'].freeze
 
-  def initialize(guids)
+  def initialize(argv)
     log_init
     # Download the existing docs
-    @target_dirs = download(ids: guids)
+    @target_dirs = download(ids: File.readlines(argv[0]).map{ |id| id.gsub("\n","") } )
   end
 
   def run
@@ -22,6 +22,10 @@ class ThePBCoreCorrector
   end
 
   private
+
+  def build_ids_array(guid_file)
+    File.readlines(guid_file).map { |id| id.tr("\n","") }
+  end
 
   def log_init
     log_file_name = Rails.root + "log/#{Time.now.strftime('%F_%T.%6N')}-pbcorecorrector.log"
@@ -122,3 +126,5 @@ class ThePBCoreCorrector
     ).run]
   end
 end
+
+ThePBCoreCorrector.new(ARGV).run

--- a/scripts/the_pbcore_corrector.rb
+++ b/scripts/the_pbcore_corrector.rb
@@ -12,7 +12,7 @@ class ThePBCoreCorrector
   def initialize(argv)
     log_init
     # Download the existing docs
-    @target_dirs = download(ids: File.readlines(argv[0]).map{ |id| id.gsub("\n","") } )
+    @target_dirs = download(ids: File.readlines(argv[0]).map { |id| id.delete("\n") })
   end
 
   def run
@@ -22,10 +22,6 @@ class ThePBCoreCorrector
   end
 
   private
-
-  def build_ids_array(guid_file)
-    File.readlines(guid_file).map { |id| id.tr("\n","") }
-  end
 
   def log_init
     log_file_name = Rails.root + "log/#{Time.now.strftime('%F_%T.%6N')}-pbcorecorrector.log"


### PR DESCRIPTION
This PR includes 2 things. First, it makes the file runnable as a script with a file path argument. That file should be a list of GUIDs. Second in testing further I found that the download method from the Downloader fails if it cannot find a specific GUID for reindexing. This PR adds a check for results before for assigning the file content, skips the ID if content if the content isn't there, and logs that it is skipping the ID.