### PR TITLE
Hide overflow for facet panel

### DIFF
--- a/app/assets/stylesheets/globals/bootstrap-killer.css.scss
+++ b/app/assets/stylesheets/globals/bootstrap-killer.css.scss
@@ -180,6 +180,7 @@
 .facets .panel-default > .panel-heading {
 	color: #292d70;
 	background-color: #dfe0ea;
+	overflow: hidden;
 }
 
 .facets .panel-group .panel + .panel {


### PR DESCRIPTION
Something must have changed in how Chrome was rendering because a scroll bar began to appear on the facet panels. The CSS property overflow on the div was being set to auto. Setting to hidden for the facet panel fixed the issue. Closes #2191 