### PR TITLE
2189 Radio Buttons

### DIFF
--- a/app/assets/stylesheets/globals/normalize.css.scss
+++ b/app/assets/stylesheets/globals/normalize.css.scss
@@ -612,6 +612,7 @@ html input[disabled] {
  */
 input[type="checkbox"],
 input[type="radio"] {
+  margin: 4px;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box; /* 1 */

--- a/app/helpers/blacklight/facets_helper_behavior.rb
+++ b/app/helpers/blacklight/facets_helper_behavior.rb
@@ -128,10 +128,10 @@ module Blacklight::FacetsHelperBehavior
   # @option options [Boolean] :suppress_link display the facet, but don't link to it
   # @return [String]
 
-  # Overriding blacklight's standard facet display to use radio buttons
+  # Overriding blacklight's standard facet display to use checkboxes
   def render_facet_value(facet_field, item, options ={})
     path = search_action_path(add_facet_params_and_redirect(facet_field, item))
-    link_to_unless(options[:suppress_link], radio_button_tag(facet_display_value(facet_field, item), facet_display_value(facet_field, item), false) + facet_display_value(facet_field, item), path, :class => "facet_select") + render_facet_count(item.hits)
+    link_to_unless(options[:suppress_link], check_box_tag(facet_display_value(facet_field, item), facet_display_value(facet_field, item), false) + facet_display_value(facet_field, item), path, :class => "facet_select") + render_facet_count(item.hits)
     # content_tag(:span, :class => "facet-label") do
     #   link_to_unless(options[:suppress_link], facet_display_value(facet_field, item), path, :class=>"facet_select")
     # end + render_facet_count(item.hits)
@@ -141,12 +141,12 @@ module Blacklight::FacetsHelperBehavior
   # Standard display of a SELECTED facet value (e.g. without a link and with a remove button)
   # @params (see #render_facet_value)
 
-  # Overriding blacklight's standard facet display to use radio buttons
+  # Overriding blacklight's standard facet display to use checkboxes
   def render_selected_facet_value(facet_field, item)
-    link_to(radio_button_tag(facet_display_value(facet_field, item), facet_display_value(facet_field, item), true) + facet_display_value(facet_field, item), search_action_path(remove_facet_params(facet_field, item, params)), :class=>"facet_select") + render_facet_count(item.hits)
+    link_to(check_box_tag(facet_display_value(facet_field, item), facet_display_value(facet_field, item), {  checked: true }) + facet_display_value(facet_field, item), search_action_path(remove_facet_params(facet_field, item, params)), :class=>"facet_select") + render_facet_count(item.hits)
   end
 
-  # New method, to not use radio buttons for organization states (joined together org values with " OR " in teh view)
+  # New method, to not use checkboxes buttons for organization states (joined together org values with " OR " in teh view)
   def render_super_facet_value(facet_field, item, options ={})
     path = search_action_path(add_facet_params_and_redirect(facet_field, item))
 

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -217,10 +217,10 @@ describe 'Catalog' do
           # commenting out as this appears to be standard Blacklight functionality
           # expect_count(43, page.text)
           # expect(page).to have_text('You searched for: Access all'), missing_page_text_custom_error('You searched for: Access all', page.current_path)
-          expect(page).to have_field('KQED__CA__KQED__CA_', checked: false)
+          expect(page).to have_field('KQED__CA_', checked: false)
           # turn on
           click_link('KQED (CA)')
-          expect(page).to have_field('KQED__CA__KQED__CA_', checked: true)
+          expect(page).to have_field('KQED__CA_', checked: true)
           expect_count(3, page.text)
           expect(page).to have_text('You searched for: Access all Remove constraint Access: all '\
                                     'Contributing Organizations KQED (CA) Remove constraint Contributing Organizations: KQED (CA)'), missing_page_text_custom_error('You searched for: Access all Remove constraint Access: all '\


### PR DESCRIPTION
Replaces radio buttons for facets with checkboxes. Radio buttons stopped working in Firefox because they're not valid in this case. Closes #2189 