### PR TITLE
Decreases font size for gallery header

### DIFF
--- a/app/assets/stylesheets/locals/media-mobile.css.scss
+++ b/app/assets/stylesheets/locals/media-mobile.css.scss
@@ -112,7 +112,7 @@
 
   .gallery-header {
     h1 {
-      font-size: 22px;
+      font-size: 1.1em;
     }
   }
 


### PR DESCRIPTION
For special collections on mobile, the titles are getting chopped off.
The real fix is to be able to nicely display full title regardless of length,
however there are some practical limitation to that. Shrinking the font size
works for many of the titles as a quick fix.