### PR TITLE
Removes splitting on case change in unstemmed SOLR text fields

### DIFF
--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -475,7 +475,7 @@
    <analyzer type="index">
     <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
-    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" />
+    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0" />
     <filter class="solr.LowerCaseFilterFactory" />
     <!-- dont double include identical terms -->
     <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
@@ -483,7 +483,7 @@
    <analyzer type="query">
     <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
-    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
+    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" />
     <filter class="solr.LowerCaseFilterFactory" />
     <!-- dont double include identical terms -->
     <filter class="solr.RemoveDuplicatesTokenFilterFactory" />


### PR DESCRIPTION
In the unstemmed text fields, we had a setting set that would split a word based on a case change in the middle word. "MacDonald" would get split in to "mac" and "donald." Without the split, now we should get "macdonald" as expected. Closes #2285 

Attaching a screenshot for tests. These 2 always fail for me locally. 
<img width="950" alt="Screen Shot 2021-07-26 at 1 57 51 PM" src="https://user-images.githubusercontent.com/3814190/127058576-673ffc13-2788-4dca-9c0d-00e4e4e0e5bd.png">
