### PR TITLE
Uses URI::escape instead of CGI::escape for links to titles

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -143,7 +143,7 @@
         <dd><a href="/catalog?f[<%=
             type.downcase.gsub(/\s/,'_')
           %>_titles][]=<%=
-            CGI::escape(title.gsub(/(["\\])/, '\\\\\1')) # escape Solr meta-characters
+            URI::escape(title.gsub(/(["\\])/, '\\\\\1')) # escape Solr meta-characters
           %>"><%= title %></a></dd>
       </dl>
     <% end %>


### PR DESCRIPTION
CGI::escape for PBCore titles in catalog#show is converting spaces in the titles to "+" which is causing issues when our newsletter system converts those "+" to "%2B" as that gets literally interpreted by SOLR as part of the title. URI:escape converts the space in a title to "%20" which works.

Tests pass locally except for these 2 which never do. 

<img width="947" alt="Screen Shot 2021-08-10 at 1 38 40 PM" src="https://user-images.githubusercontent.com/3814190/128931996-1d9bc0a7-e9c3-4bd4-9329-459341321851.png">
