### PR TITLE
Adds Sorting Config for Existing Exhibits

### DIFF
--- a/config/exhibits.yml
+++ b/config/exhibits.yml
@@ -19,3 +19,67 @@
   - "eotp/5-6-religious-leaders"
   - "eotp/5-7-labor-business"
   - "eotp/5-8-students-educators"
+"climate-change":
+  sections:
+  - climate-change/history
+  - climate-change/causes
+  - climate-change/impacts
+  - climate-change/advocacy
+  - climate-change/communicating-art
+  - climate-change/solutions
+"station-histories":
+  sections:
+  - station-histories/first-broadcasts
+  - station-histories/dedication-ceremonies
+  - station-histories/restrospective-anniversaries
+  - station-histories/public-broadcasting-act
+"presidential-elections":
+  sections:
+  - presidential-elections/process
+  - presidential-elections/candidates
+  - presidential-elections/voters-issues
+"black-power":
+  sections:
+  - black-power/black-journal
+  - black-power/soul
+"conservatism":
+  sections:
+  - conservatism/politics-net
+  - conservatism/defining-conservatism
+  - conservatism/conservatism-gop
+  - conservatism/conservatism-civil-rights
+  - conservatism/conservatism-media
+"first-amendment":
+  sections:
+  - first-amendment/protesting-activities
+  - first-amendment/protests-60s-70s
+  - first-amendment/protests-80s-andbeyond
+"historic-preservation":
+  sections:
+  - historic-preservation/traditional-preservation
+  - historic-preservation/marginalized-perspectives
+  - historic-preservation/urban-renewal
+  - historic-preservation/economic
+  - historic-preservation/natural-environment
+"civil-rights":
+  sections:
+  - civil-rights/places
+  - civil-rights/organizations
+  - civil-rights/people
+"watergate":
+  sections:
+  - watergate/the-watergate-scandal-1972-1974
+  - watergate/watergate-and-public-broadcasting
+  - watergate/cast-of-characters
+  - watergate/the-watergate-coverage
+  - watergate/the-impeachment-coverage
+"education":
+  sections:
+  - education/education-documentaries-in-the-net-years-1953-1972
+  - education/capturing-education-battles-on-television-1972-1980
+  - education/covering-education-in-the-1980s
+  - education/national-education-reforms-on-local-television-1990-today
+"newsmagazines":
+  sections:
+  - newsmagazines/precedents
+  - newsmagazines/definitive-newsmags


### PR DESCRIPTION
Sorting for Exhibits moved from the head_html attribute on the CMLess Exhibit to an exhibits.yml config file. This PR adds the sorting that was present in the markdown files to the appropriate config file.