### PR TITLE
Creates AAPB.valid_id?(id), Refactors delete_records.rb to use a class and adds tests

### DIFF
--- a/lib/aapb.rb
+++ b/lib/aapb.rb
@@ -10,4 +10,8 @@ module AAPB
   PLAYER_WIDTH_TRANSCRIPT_16_9 = '562'.freeze
   PLAYER_HEIGHT_NO_TRANSCRIPT_16_9 = '383'.freeze
   PLAYER_WIDTH_NO_TRANSCRIPT_16_9 = '680'.freeze
+
+  def self.valid_id?(id)
+    id =~ /\Acpb-aacip[\-_\/](\S*)/ ? true : false
+  end
 end

--- a/scripts/delete_records.rb
+++ b/scripts/delete_records.rb
@@ -1,15 +1,4 @@
-require_relative '../lib/rails_stub'
-require_relative '../app/models/exhibit'
-require_relative 'lib/downloader'
-require_relative 'lib/cleaner'
-require_relative 'lib/pb_core_ingester'
-require 'logger'
-require 'rake'
+require_relative 'lib/deleter'
 
 args = ARGV
-ingester = PBCoreIngester.new
-unless args.all? { |id| %r{\Acpb-aacip[\-_\/][0-9]{1,3}[\-_\/][a-zA-Z0-9]+\z} =~ id }
-  puts "Got a non-GUID argument! That's not cool!"
-  exit 1
-end
-ingester.delete_records(args)
+Deleter.new(args).delete

--- a/scripts/lib/deleter.rb
+++ b/scripts/lib/deleter.rb
@@ -1,0 +1,33 @@
+require_relative '../../lib/rails_stub'
+require_relative '../../app/models/exhibit'
+require_relative '../lib/downloader'
+require_relative '../lib/cleaner'
+require_relative '../lib/pb_core_ingester'
+require 'logger'
+require 'rake'
+
+class Deleter
+
+  def initialize(ids)
+    @ids = validate_ids(ids)
+  end
+
+  def delete
+    ingester.delete_records(@ids)
+  end
+
+  private
+
+  def validate_ids(ids)
+    raise 'Invalid arguments for deleting AAPB records. Must be an Array of IDs.' unless ids.is_a? Array
+    unless ids.all? { |id| AAPB.valid_id?(id) }
+      puts "Got a non-GUID argument! That's not cool!"
+      exit 1
+    end
+    ids
+  end
+
+  def ingester
+    PBCoreIngester.new
+  end
+end

--- a/spec/lib/aapb_spec.rb
+++ b/spec/lib/aapb_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'aapb'
+
+describe AAPB do
+
+  describe '#valid_id' do
+    it 'returns true for an ids that begin with cpb-aacip(-|_|/)' do
+      %w(cpb-aacip-111-21ghx7d6 cpb-aacip-a1bcd4fc0e1 cpb-aacip_111-21ghx7d6 cpb-aacip/111-21ghx7d6).each do |id|
+        expect(AAPB.valid_id?(id)).to eq(true)
+      end
+    end
+
+    it 'returns false for other ids' do
+      [ 1,  "1", "not-an-id" ].each do |id|
+        expect(AAPB.valid_id?(id)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/scripts/deleter_spec.rb
+++ b/spec/scripts/deleter_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require_relative '../../scripts/lib/deleter'
+
+describe Deleter do
+
+  context 'with an Array with invalid ID' do
+    describe '.new' do
+      it 'fails on an invalid ID' do
+        expect{ Deleter.new(["123"]) }.to raise_error(SystemExit)
+      end
+    end
+  end
+
+  context 'with an Array of valid IDs' do
+    describe '.new' do
+      it 'passes ID validation' do
+        expect{ Deleter.new(["cpb-aacip-123456", "cpb-aacip-78910"]) }.not_to raise_error
+      end
+    end
+
+    describe '.delete' do
+      let(:ids) { [ "cpb-aacip-123456" ] }
+      let(:deleter) { Deleter.new(ids) }
+      let(:fake_ingester) { instance_double(PBCoreIngester) }
+
+      before do
+        allow(deleter).to receive(:ingester).and_return(fake_ingester)
+        allow(fake_ingester).to receive(:delete_records).with(ids)
+        deleter.delete
+      end
+
+      it 'passes the Array of IDs to PBCoreIngester to delete' do
+        expect(fake_ingester).to have_received(:delete_records).with(ids)
+      end
+    end
+  end
+
+  context "with something other than an Array" do
+    describe '.new' do
+      it 'raises an error' do
+        expect{ Deleter.new("cpb-aacip-123456") }.to raise_error(RuntimeError, "Invalid arguments for deleting AAPB records. Must be an Array of IDs.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
I checked to see if there were other ID validations going on where we could use the new AAPB.valid_id? method but didn't actually see any. 

Closes #2153 

These tests never pass for me locally:
<img width="717" alt="Screen Shot 2021-09-14 at 1 32 48 PM" src="https://user-images.githubusercontent.com/3814190/133329707-4f692498-b119-40ab-8d33-a406604e766e.png">
