### PR TITLE
Change Location of Logo on Peabody

### DIFF
--- a/app/assets/stylesheets/globals/exhibits.css.scss
+++ b/app/assets/stylesheets/globals/exhibits.css.scss
@@ -30,6 +30,12 @@
   padding: 0 5px;
 }
 
+.exhibit-logo {
+  float: right;
+  margin: 0;
+  padding: 0;
+}
+
 .exhibit-big-image {
   display: block;
 }

--- a/app/views/exhibits/peabody.md
+++ b/app/views/exhibits/peabody.md
@@ -27,12 +27,14 @@
 - [Peabody Awards website](https://peabodyawards.com/)
 
 ## Main
+<table class="exhibit-logo">
+  <tr><td><img src="https://s3.amazonaws.com/americanarchive.org/exhibits/nhprc-logo-small.jpg" alt="NHPRC logo"/></td></tr>
+</table>
 
-The [Peabody Awards Collection](https://americanarchive.org/special_collections/peabody) in the American Archive of Public Broadcasting presents a unique aggregation of public media: seven decades' worth of programs self-selected by broadcasters as their best work over the previous year and submitted for prestigious George Foster Peabody Awards. This collection, comprising nearly 4,000 digitized public television and radio programs, contains programs created between 1941 and 2003 by more than 230 different local, state, and regional public radio and television stations and producers in forty-six states, in addition to Puerto Rico and the District of Columbia. One hundred seventy-three of the programs are Peabody winners. Approximately twelve percent were broadcast nationally; many were seen only in their respective local viewing areas. The collection includes documentaries, public affairs programs, and science, health, children’s, and cultural programming. 
-![NHPRC logo](https://s3.amazonaws.com/americanarchive.org/exhibits/nhprc-logo-small.jpg "NHPRC logo")
- 
+The [Peabody Awards Collection](https://americanarchive.org/special_collections/peabody) in the American Archive of Public Broadcasting presents a unique aggregation of public media: seven decades' worth of programs self-selected by broadcasters as their best work over the previous year and submitted for prestigious George Foster Peabody Awards. This collection, comprising nearly 4,000 digitized public television and radio programs, contains programs created between 1941 and 2003 by more than 230 different local, state, and regional public radio and television stations and producers in forty-six states, in addition to Puerto Rico and the District of Columbia. One hundred seventy-three of the programs are Peabody winners. Approximately twelve percent were broadcast nationally; many were seen only in their respective local viewing areas. The collection includes documentaries, public affairs programs, and science, health, children’s, and cultural programming.
+
 This exhibit provides several ways to explore the AAPB’s Peabody Awards Collection, including by decade, location, and Peabody submission category. These pages feature programs available for online access in the AAPB along with a list of all Peabody Awards winners in the digitized collection, those available online as well as those accessible only on the premises of the Library of Congress, GBH and UGA. Finally, the exhibit provides a brief history of the Peabody Awards and a description of the much larger Peabody Awards Collection at the University of Georgia.
- 
+
 The AAPB and University of Georgia thank the National Historical Publications and Records Commission for the generous grant that funded the digitization of the Peabody Awards Collection and the curation of this exhibit.
 
 <table class="exhibit-image">


### PR DESCRIPTION
Adds a class to float an exhibit table right + tweaks location of NHPRC logo on the Peabody exhibit. Approved by Casey.

![Screen Shot 2021-09-15 at 10 55 59 AM](https://user-images.githubusercontent.com/3814190/133486615-9871f17d-9d5b-47d1-acdb-b17277177c05.png)
