### PR TITLE
Updates robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,5 @@
+# Only allow crawling of record details pages, i.e. /catalog/{id}
+# and not search results pages, i.e /catalog?params, or catalog.html?params
 User-agent: *
-Disallow: /catalog?
-
-User-agent: PetalBot
-Disallow: /
-
-User-agent: SemrushBot
-Disallow: /
-
-User-agent: AhrefsBot
-Disallow: /
-
-User-agent: SeznamBot
-Disallow: /
+Disallow: /catalog
+Allow: /catalog/


### PR DESCRIPTION
We want to allow crawling of record pages, but not search results pages.

Also removes config for singling out specific bots, as those rules are intended
to apply to bots that misbehave, but misbehaving bots don't always follow robots.txt.

Instead, we handle misbehaving bots (by agent identifier) in our web server config.