### PR TITLE
Fixes error when transcript file is missing (cont)

### DIFF
--- a/scripts/download_clean_ingest.rb
+++ b/scripts/download_clean_ingest.rb
@@ -1,11 +1,7 @@
-require_relative '../lib/rails_stub'
-require_relative '../app/models/exhibit'
+require ::File.expand_path('../../config/environment', __FILE__)
 require_relative 'lib/downloader'
 require_relative 'lib/cleaner'
 require_relative 'lib/pb_core_ingester'
-require 'logger'
-require 'rake'
-require 'active_support/core_ext/string'
 
 class Exception
   def short


### PR DESCRIPTION
Loads the Rails environment in download_clean_ingest.rb instead of stubbing the Rails module.

The use of ExternalFile within the ingest context was brittle because for some
reason thed download_clean_ingest.rb is explicitly avoiding loading the Rails
environment, and instead methods on the Rails module, such as .cache, and
simply calling Rails.cache.delete in the ExternalFile class caused the ingest
script to fail.

Not sure why the Rails environment was deliberately avoided during the ingest script, other
than a way to save on memory. But it's weird, and leads to brittle code, as this case
highlights.