### PR TITLE
Update Homepage menu

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -152,9 +152,9 @@
 <div id="homenav" class="well well-sm affix-top hidden-xs" data-spy="affix" data-offset-top="250">
   <ul class="nav nav-pills">
     <li role="presentation" class="aa-link"><a href="#top">American Archive</a></li>
+    <li role="presentation"><a href="/special_collections">Special Collections</a></li>
+    <li role="presentation"><a href="/exhibits">Exhibits</a></li>
     <li role="presentation"><a href="#stations">Organizations</a></li>
-    <li role="presentation"><a href="#special-collections">Special Collections</a></li>
-    <li role="presentation"><a href="#exhibits">Exhibits</a></li>
     <li role="presentation"><a href="#help-us">Help Us!</a></li>
     <li role="presentation"><a href="#browse">Browse</a></li>
     <li role="presentation"><a href="#video">Our Story</a></li>


### PR DESCRIPTION
# Homepage search menu
- Links go to page, not homepage fragment
  - `#special-collections` => `special_collections`
  - `#exhibits` => `/exhibits`
- Changed menu order
  - Special Collections
  - Exhibits
  - Organizations
  - ...

Closes #2127