### PR TITLE
Move "Other Resources" below collection search to reduce whitespace

### DIFF
--- a/app/views/special_collections/show.html.erb
+++ b/app/views/special_collections/show.html.erb
@@ -8,7 +8,19 @@
     <div class="col-md-6 collection-image">
       <img src="<%= @special_collection.thumbnail_url %>" alt="<%= @special_collection.title %>" aria-hidden="true">
       <%= render partial: 'collection_search' %>
-    </div>
+    <% if !@special_collection.resources.empty? %>
+      <div class="resources-row">
+        <h2>Other Resources</h2>
+        <div class="col-md-12 collection-resources">
+          <ul>
+            <% @special_collection.resources.each do |resource| %>
+                <li><%= link_to resource[0], resource[1], target: "_blank" %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+  </div>
     <div class="col-md-6 collection-about-col">
       <div class="collection-about">
         <h2>Collection Summary</h2>
@@ -63,19 +75,6 @@
             </div>
           </div>
         <% end %>
-      <% end %>
-
-      <% if !@special_collection.resources.empty? %>
-        <div class="row resources-row">
-          <h2>Other Resources</h2>
-          <div class="col-md-12 collection-resources">
-            <ul>
-              <% @special_collection.resources.each do |resource| %>
-                  <li><%= link_to resource[0], resource[1], target: "_blank" %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Fixes #2319
### Because
Special Collections with long `Summary` blocks creates a large whitespace on the left side of the page.

Example: https://americanarchive.org/special_collections/radio-kdna

### Changes
This moves the `Other Resources` box to the left column, below the thumbnail and search box.

### Side effects
- On mobile, `Other Resources` will appear before the summary

### Other possible changes to make
- There is a `Funders` block, which was above `Other Resources`
  - Should this be moved as well?
- Large `Summary` blocks still have large whitespace, but now slightly less
- Should we move blocks below the `Summary` on the right column?
  - Collection Background
  - Featured Items