### PR TITLE
iframe proportions

### DIFF
--- a/app/assets/stylesheets/globals/exhibits.css.scss
+++ b/app/assets/stylesheets/globals/exhibits.css.scss
@@ -31,8 +31,12 @@
   min-height: auto;
   aspect-ratio: 16 / 9;
 }
+@media only screen and (min-width: 992px) {
+#exhibit-main iframe.exhibit-small-iframe {
+  max-width: 80%;
+  margin-left: 10%;
 }
-
+}
 .exhibit-image {
   float: right;
   padding: 0 5px;

--- a/app/assets/stylesheets/globals/exhibits.css.scss
+++ b/app/assets/stylesheets/globals/exhibits.css.scss
@@ -27,12 +27,10 @@
 
 #exhibit-main iframe.exhibit-small-iframe {
   width: 100%;
-  max-width: 50%;
-  min-width: 33%;
-  min-height: 45vh;
   height: auto;
-
-  margin-left: 25%;
+  min-height: auto;
+  aspect-ratio: 16 / 9;
+}
 }
 
 .exhibit-image {


### PR DESCRIPTION
# Aspect ratio
- Fixes aspect ratio of iframe videos with `.exhibit-small-iframe`
  - `aspect-ratio: 16 / 9;`
- All podcast videos now show entire thumbnail
  - no cropping text or images

## Width
- Mobile first:
  - Default `width: 100%`
- Large screens
  - `min-width: 992px`
    - `max-width: 80%`
    - `margin-left: 10%`
 
Closes #2436, closes #2432