### PR TITLE
Restore podcast link

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -78,7 +78,7 @@
                       <li class="instagram"><a class="footer-sprite" href="https://www.instagram.com/amarchivepub/" target="_blank" title="Follow us on Instagram">Follow us on Instagram</a></li>
                     </ul>
                     <ul class="social list-unstyled">
-                      <li class="podcast"><a href="https://feeds.feedburner.com/PresentingThePastExploringTheAmericanArchiveOfPublicBroadcasting" target="_blank" title="Listen to our Podcast">Listen to our Podcast</a></li>
+                      <li class="podcast"><a href="https://americanarchive.org/about-the-american-archive/podcast" target="_blank" title="Listen to our Podcast">Listen to our Podcast</a></li>
 
                     </ul>
                   <% end %>


### PR DESCRIPTION
# Restore podcast link
Restores podcast link to podcast homepage: https://americanarchive.org/about-the-american-archive/podcast

Closes #2439

Because: https://github.com/WGBH-MLA/AAPB2/pull/2425#issuecomment-1151335726