### PR TITLE
2464 change homepage og image to aapb logo

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :head do %>
   <meta name="description" content="A collaboration between GBH and the Library of Congress with a long-term vision to preserve and make accessible significant historical content created by public media.">
 
+  <meta property="og:image" content="/site-ui/logo-mobile.png" />
   <%= javascript_include_tag 'background-video' %>
 <% end %>
 

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :head do %>
   <meta name="description" content="A collaboration between GBH and the Library of Congress with a long-term vision to preserve and make accessible significant historical content created by public media.">
 
-  <meta property="og:image" content="/site-ui/logo-mobile.png" />
+  <meta property="og:image" content="https://americanarchive.org/site-ui/logo-mobile.png" />
   <%= javascript_include_tag 'background-video' %>
 <% end %>
 


### PR DESCRIPTION
This should replace the picture of Phyllis Schlafly when americanarchive.org is shown as a link preview in outlook, facebook, and other websites.