### PR TITLE
Change all "Watch from here" to "Access from here"

### DIFF
--- a/app/helpers/snippet_helper.rb
+++ b/app/helpers/snippet_helper.rb
@@ -4,7 +4,7 @@ module SnippetHelper
     if timecode_url
       timecode_link = %(
         <a href="#{timecode_url}">
-          <button type="button" class="btn btn-default snippet-link">#{media_type == 'Moving Image' ? "Watch" : "Listen"} from here</button>
+          <button type="button" class="btn btn-default snippet-link">Access from here</button>
         </a>
       )
     end

--- a/spec/helpers/snippet_helper_spec.rb
+++ b/spec/helpers/snippet_helper_spec.rb
@@ -89,7 +89,7 @@ describe SnippetHelper do
 
   describe 'view snippet helpers' do
     it 'creates a timecode transcript snippet for the frontend' do
-      expect(transcript_snippet(transcript_snippet_1.snippet, "Moving Image", transcript_snippet_1.url_at_timecode)).to eq(%(\n      <span class=\"index-data-title\">From Transcript</span>:\n      <p style=\"margin-top: 0;\"> FOR THIS 15TH ANNIVERSARY CELEBRATION AND DEDICATION CEREMONY IS MR GEORGE CAMPBELL CHAIRMAN OF THE <mark>ARKANSAS</mark> EDUCATIONAL TELEVISION COMMISSION GOOD AFTERNOON DISTINGUISHED GUESTS LADIES AND GENTLEMEN \n        \n        <a href=\"/catalog/cpb-aacip-111-21ghx7d6?term=ARKANSAS&proxy_start_time=50.24\">\n          <button type=\"button\" class=\"btn btn-default snippet-link\">Watch from here</button>\n        </a>\n      \n      </p>\n    ))
+      expect(transcript_snippet(transcript_snippet_1.snippet, "Moving Image", transcript_snippet_1.url_at_timecode)).to eq(%(\n      <span class=\"index-data-title\">From Transcript</span>:\n      <p style=\"margin-top: 0;\"> FOR THIS 15TH ANNIVERSARY CELEBRATION AND DEDICATION CEREMONY IS MR GEORGE CAMPBELL CHAIRMAN OF THE <mark>ARKANSAS</mark> EDUCATIONAL TELEVISION COMMISSION GOOD AFTERNOON DISTINGUISHED GUESTS LADIES AND GENTLEMEN \n        \n        <a href=\"/catalog/cpb-aacip-111-21ghx7d6?term=ARKANSAS&proxy_start_time=50.24\">\n          <button type=\"button\" class=\"btn btn-default snippet-link\">Access from here</button>\n        </a>\n      \n      </p>\n    ))
     end
 
     it 'creates a transcript snippet for the frontend' do


### PR DESCRIPTION
# "Access from here"
Change `"Watch..."` to `"Access..."` because not all content is video. 

Also, the controller can't distinguish between the two without creating a new `PBCorePresenter` for each search result.

Closes #2452