### PR TITLE
Record title search link: show all results

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -148,7 +148,7 @@
             type.downcase.gsub(/\s/,'_')
           %>_titles][]=<%=
             URI::encode_www_form_component(title.gsub(/(["\\])/, '\\\\\1')) # escape Solr meta-characters
-          %>"><%= title %></a></dd>
+          %>&f[access_types][]=all"><%= title %></a></dd>
       </dl>
     <% end %>
 


### PR DESCRIPTION
# Title search
On a record, when clicking on a search link from a title field, the link now includes `&f[access_types][]=all` to show all records, not just the search default of `online`.

Closes MLAAAPB-60