### PR TITLE
Refactor search query with quotes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -194,7 +194,7 @@ class CatalogController < ApplicationController
 
     # pull this out because we're going to mutate it inside terms_array method
     @query = params[:q].dup
-    @terms_array = query_to_terms_array(@query)
+    @terms_array = QueryToTermsArray.new(@query).terms_array
 
     if !params[:f] || !params[:f][:access_types]
       # Sets Access Level

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -17,7 +17,7 @@ class SnippetsController < ApplicationController
         snippet_data = {}
 
         # make array of words from users search query
-        terms_array = query_to_terms_array(params["query"])
+        terms_array = QueryToTermsArray.new(params["query"]).terms_array
 
         # do, a search
         solr_docs = query_from_solr(solr_q)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,59 +10,6 @@ module ApplicationHelper
     nil
   end
 
-  def stopwords
-    Rails.cache.fetch('stopwords') do
-      sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
-      sw.reject do |word|
-        word =~ /^#/ || word.empty?
-      end
-    end
-  end
-
-  def remove_stopwords(terms_array)
-    terms_array - stopwords
-  end
-
-  def extract_quoted_phrases(query)
-    query.scan(/"([^"]*)"/)
-  end
-
-  def strip_punctuation(query)
-    query.gsub(/[[:punct:]]/, '')
-  end
-
-  def query_to_terms_array(query)
-    return [] if !query || query.empty?
-    query = query.upcase
-
-    # if there are an even number of double quotes
-    if query.count('"') % 2 == 0
-      quotes = extract_quoted_phrases(query)
-
-      quotes = quotes.map do |phrase|
-
-        # Remove quotes from query
-        query.remove!(phrase.first)
-
-        # clean each phrase and split to arrary
-        strip_punctuation(phrase.first).split(' ')
-      end
-
-      # Remove punctuation from unquoted bits
-      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
-
-      # Remove any unquoted stopwords
-      unquotes = remove_stopwords(unquotes)
-
-      # return combined quotes and unquotes
-      terms_array = quotes + unquotes
-    else
-      # query has no quotes
-      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
-      terms_array = [unquotes - stopwords]
-    end
-  end
-
   def get_last_day(month)
     if %w(04 06 09 11).include?(month)
       '30'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,8 +39,14 @@ module ApplicationHelper
       if query.count('"') % 2 == 0
           quotes = extract_quoted_phrases(query)
           
+          quotes = quotes.map do |phrase|
+
           # Remove quotes from query
-          quotes.each {|q| query.remove!(q.first)}
+            query.remove!(phrase.first)
+
+            # clean each phrase and split to arrary
+            strip_punctuation(phrase.first).split(' ')
+          end
 
           # Remove punctuation from unquoted bits
           unquotes = strip_punctuation(query).split(" ").map(&:strip)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
   end
 
   def get_stopwords()
-    stopwords = Rails.cache.fetch("stopwords") do
+    stopwords = Rails.cache.fetch('stopwords') do
       sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
       sw.reject do |word|
         word =~ /^#/ || word.empty?
@@ -20,48 +20,47 @@ module ApplicationHelper
   end
 
   def remove_stopwords(terms_array)
-      terms_array - get_stopwords
+    terms_array - get_stopwords
   end
 
   def extract_quoted_phrases(query)
-      query.scan(/"([^"]*)"/)
+    query.scan(/"([^"]*)"/)
   end
 
   def strip_punctuation(query)
-      query.gsub(/[[:punct:]]/, '')
+    query.gsub(/[[:punct:]]/, '')
   end
 
   def query_to_terms_array(query)
-      return [] if !query || query.empty?
-      query = query.upcase
+    return [] if !query || query.empty?
+    query = query.upcase
 
-      # if there are an even number of double quotes
-      if query.count('"') % 2 == 0
-          quotes = extract_quoted_phrases(query)
-          
-          quotes = quotes.map do |phrase|
+    # if there are an even number of double quotes
+    if query.count('"') % 2 == 0
+      quotes = extract_quoted_phrases(query)
 
-            # Remove quotes from query
-            query.remove!(phrase.first)
+      quotes = quotes.map do |phrase|
 
-            # clean each phrase and split to arrary
-            strip_punctuation(phrase.first).split(' ')
-          end
+        # Remove quotes from query
+        query.remove!(phrase.first)
 
-          # Remove punctuation from unquoted bits
-          unquotes = strip_punctuation(query).split(' ').map {|term| [term.strip]}
-
-          # Remove any unquoted stopwords
-          unquotes = remove_stopwords(unquotes)
-
-          # return combined quotes and unquotes
-          terms_array = quotes + unquotes
-
-      else
-        # query has no quotes
-        unquotes = strip_punctuation(query).split(' ').map {|term| [term.strip]}
-        terms_array = [unquotes - get_stopwords]
+        # clean each phrase and split to arrary
+        strip_punctuation(phrase.first).split(' ')
       end
+
+      # Remove punctuation from unquoted bits
+      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
+
+      # Remove any unquoted stopwords
+      unquotes = remove_stopwords(unquotes)
+
+      # return combined quotes and unquotes
+      terms_array = quotes + unquotes
+    else
+      # query has no quotes
+      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
+      terms_array = [unquotes - get_stopwords]
+    end
   end
 
   def get_last_day(month)
@@ -78,15 +77,13 @@ module ApplicationHelper
     # type => before, after, index
     # 0000-00-00
     if /\A\d{4}\-\d{1,2}\-\d{1,2}\z/ =~ date_val
-
       year, month, day = date_val.scan(/\A(\d{4})\-(\d{1,2})\-(\d{1,2})\z/).flatten
 
-    # 0000-00
+      # 0000-00
     elsif /\A\d{4}\-\d{1,2}\z/ =~ date_val
-
       year, month = date_val.scan(/\A(\d{4})\-(\d{1,2})\z/).flatten
 
-    # 0000
+      # 0000
     elsif /\A\d{4}\z/ =~ date_val
       date_was_reset = true
       year = date_val

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,12 +14,10 @@ module ApplicationHelper
     return [] if !query || query.empty?
 
     stopwords = Rails.cache.fetch("stopwords") do
-      sw = []
-      File.read(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt')).each_line do |line|
-        next if line.start_with?('#') || line.empty?
-        sw << line.upcase.strip
+      sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true)
+      sw.reject do |word|
+        word =~ /^#/ || word.empty?
       end
-      sw
     end
 
     terms_array = if query.include?(%("))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,8 @@ module ApplicationHelper
     nil
   end
 
-  def get_stopwords()
-    stopwords = Rails.cache.fetch('stopwords') do
+  def stopwords
+    Rails.cache.fetch('stopwords') do
       sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
       sw.reject do |word|
         word =~ /^#/ || word.empty?
@@ -20,7 +20,7 @@ module ApplicationHelper
   end
 
   def remove_stopwords(terms_array)
-    terms_array - get_stopwords
+    terms_array - stopwords
   end
 
   def extract_quoted_phrases(query)
@@ -59,7 +59,7 @@ module ApplicationHelper
     else
       # query has no quotes
       unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
-      terms_array = [unquotes - get_stopwords]
+      terms_array = [unquotes - stopwords]
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,7 +35,8 @@ module ApplicationHelper
       return [] if !query || query.empty?
       query = query.upcase
 
-      if query.include?(%("))
+      # if there are an even number of double quotes
+      if query.count('"') % 2 == 0
           quotes = extract_quoted_phrases(query)
           
           # Remove quotes from query

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,12 +11,12 @@ module ApplicationHelper
   end
 
   def get_stopwords()
-      stopwords = Rails.cache.fetch("stopwords") do
+    stopwords = Rails.cache.fetch("stopwords") do
       sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
       sw.reject do |word|
         word =~ /^#/ || word.empty?
-          end
       end
+    end
   end
 
   def remove_stopwords(terms_array)
@@ -41,7 +41,7 @@ module ApplicationHelper
           
           quotes = quotes.map do |phrase|
 
-          # Remove quotes from query
+            # Remove quotes from query
             query.remove!(phrase.first)
 
             # clean each phrase and split to arrary
@@ -49,18 +49,18 @@ module ApplicationHelper
           end
 
           # Remove punctuation from unquoted bits
-          unquotes = strip_punctuation(query).split(" ").map(&:strip)
+          unquotes = strip_punctuation(query).split(' ').map {|term| [term.strip]}
 
-          # Remove any unquoted stopwords 
+          # Remove any unquoted stopwords
           unquotes = remove_stopwords(unquotes)
 
           # return combined quotes and unquotes
           terms_array = quotes + unquotes
+
       else
         # query has no quotes
-        unquotes = strip_punctuation(query).split(' ').map(&:strip)
+        unquotes = strip_punctuation(query).split(' ').map {|term| [term.strip]}
         terms_array = [unquotes - get_stopwords]
-        # require 'pry'; binding.pry
       end
   end
 

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -45,7 +45,7 @@
   $(document).ready(function() {
     <% if @query.present? && @snippets && @snippets.keys.present? %>
       var guids = <%= raw(@snippets.keys).to_s %>
-      var q = "<%= @query %>"
+      var q = `<%= raw @query %>`
       getSnippets(guids, q)
     <% end %>
   })

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -30,11 +30,11 @@ class QueryToTermsArray
         query.remove!(phrase.first)
 
         # split each phrase to word arrary
-        phrase.first.split(' ')
+        phrase.first.split
       end
 
       # Remove punctuation from unquoted bits
-      unquotes = strip_punctuation(query).split(' ')
+      unquotes = strip_punctuation(query).split
 
       # Remove any unquoted stopwords and convert to term array
       unquotes = remove_stopwords(unquotes).map { |term| [term] }
@@ -43,11 +43,11 @@ class QueryToTermsArray
       @terms_array = quotes + unquotes
     else
       # query has no quotes. Clean and split
-      unquotes = strip_punctuation(query).split(' ')
+      unquotes = strip_punctuation(query).split
 
       # Remove stopwords and convert to term array
-      unquotes = remove_stopwords(unquotes).map { |term| [term] }
-      @terms_array = unquotes
+      @terms_array  = remove_stopwords(unquotes).map { |term| [term] }
+      
     end
   end
 
@@ -58,6 +58,8 @@ class QueryToTermsArray
   def stopwords
     Rails.cache.fetch('stopwords') do
       sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
+      
+      # Remove comments and empty lines
       sw.reject do |word|
         word =~ /^#/ || word.empty?
       end

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -3,13 +3,13 @@
 #
 # The class converts a text query into an array of terms according to the
 # following rules:
+# * Query terms are capitalized
 # * Query terms not in double quotes are put into single-element arrays.
 # * Query terms within double quotes are put into an array where each element
 #   is a term within the double-quoted phrase.
 # * Stopwords are not removed from double-quoted phrases.
 # * Stopwords are removed from unquoted query terms.
-# * Special characters, in this case any non-alphanumeric, non-space character
-#   is removed.
+# * Special characters (any non-alphanumeric, non-space character) are removed.
 #
 # @see ./spec/lib/query_to_terms_array_spec.rb
 # @see SnippetHelper::Snippet - class that uses output from
@@ -70,7 +70,7 @@ class QueryToTermsArray
   def strip_special_chars(str)
     str.
       # Replace any non-alphanumeric, non-space character with a single space,
-      gsub(/[^[:alpha:] ]/, ' ').
+      gsub(/[^[:alnum:] ]/, ' ').
       # and collapse multiple whitespace down to single space,
       gsub(/\s+/, ' ').
       # and strip whitespace off front and back of string.

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -10,7 +10,7 @@ class QueryToTermsArray
     if query.count('"').even?
       quotes = extract_quoted_phrases(query)
 
-      quotes = quotes.map do |phrase|
+      quotes.map! do |phrase|
         # Remove quotes from query
         query.remove!(phrase.first)
 
@@ -21,15 +21,18 @@ class QueryToTermsArray
       # Remove punctuation from unquoted bits
       unquotes = strip_punctuation(query).split(' ')
 
-      # Remove any unquoted stopwords
-      unquotes = remove_stopwords(unquotes).map { |term| [term.strip] }
+      # Remove any unquoted stopwords and convert to term array
+      unquotes = remove_stopwords(unquotes).map { |term| [term] }
 
       # return combined quotes and unquotes
       @terms_array = quotes + unquotes
     else
-      # query has no quotes
-      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
-      @terms_array = [unquotes - stopwords]
+      # query has no quotes. Clean and split
+      unquotes = strip_punctuation(query).split(' ')
+
+      # Remove stopwords and convert to term array
+      unquotes = remove_stopwords(unquotes).map { |term| [term] }
+      @terms_array = unquotes
     end
   end
 
@@ -53,6 +56,7 @@ class QueryToTermsArray
   end
 
   def strip_punctuation(query)
-    query.gsub(/[^\w\s]/, '')
+    # Removes any non alphanumeric or space character
+    query.gsub(/[^[:alpha:] ]/, '')
   end
 end

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -1,0 +1,62 @@
+class QueryToTermsArray
+  attr_reader :query, :terms_array
+
+  def initialize(query)
+    @query = query
+    return [] if !query || query.empty?
+    query = query.upcase
+
+    # if there are an even number of double quotes
+    if query.count('"') % 2 == 0
+      quotes = extract_quoted_phrases(query)
+
+      quotes = quotes.map do |phrase|
+
+        # Remove quotes from query
+        query.remove!(phrase.first)
+
+        # clean each phrase and split to arrary
+        strip_punctuation(phrase.first).split(' ')
+      end
+
+      # Remove punctuation from unquoted bits
+      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
+
+      # Remove any unquoted stopwords
+      unquotes = remove_stopwords(unquotes)
+
+      # return combined quotes and unquotes
+      @terms_array = quotes + unquotes
+    else
+      # query has no quotes
+      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
+      @terms_array = [unquotes - stopwords]
+    end
+  end
+
+  private
+
+  def stopwords
+    Rails.cache.fetch('stopwords') do
+      sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
+      sw.reject do |word|
+        word =~ /^#/ || word.empty?
+      end
+    end
+  end
+
+  def remove_stopwords(terms_array)
+    terms_array - stopwords
+  end
+
+  def extract_quoted_phrases(query)
+    query.scan(/"([^"]*)"/)
+  end
+
+  def strip_punctuation(query)
+    query.gsub(/[[:punct:]]/, '')
+  end
+end
+
+# And can be used in controllers like this...
+# terms_array = QueryToTermsArray.new(query).term_array

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -28,7 +28,6 @@ class QueryToTermsArray
 
   # @param [String] query The search query
   def initialize(query)
-    raise ArgumentError, "expected query to not be empty" if query.to_s.empty?
     @query = query.to_s.upcase
   end
 

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -46,8 +46,8 @@ class QueryToTermsArray
       unquotes = strip_punctuation(query).split
 
       # Remove stopwords and convert to term array
-      @terms_array  = remove_stopwords(unquotes).map { |term| [term] }
-      
+      @terms_array = remove_stopwords(unquotes).map { |term| [term] }
+
     end
   end
 
@@ -58,7 +58,7 @@ class QueryToTermsArray
   def stopwords
     Rails.cache.fetch('stopwords') do
       sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
-      
+
       # Remove comments and empty lines
       sw.reject do |word|
         word =~ /^#/ || word.empty?

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -20,10 +20,10 @@ class QueryToTermsArray
       end
 
       # Remove punctuation from unquoted bits
-      unquotes = strip_punctuation(query).split(' ').map { |term| [term.strip] }
+      unquotes = strip_punctuation(query).split(' ')
 
       # Remove any unquoted stopwords
-      unquotes = remove_stopwords(unquotes)
+      unquotes = remove_stopwords(unquotes).map { |term| [term.strip] }
 
       # return combined quotes and unquotes
       @terms_array = quotes + unquotes
@@ -54,7 +54,7 @@ class QueryToTermsArray
   end
 
   def strip_punctuation(query)
-    query.gsub(/[[:punct:]]/, '')
+    query.gsub(/[^\w\s]/, '')
   end
 end
 

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -14,8 +14,8 @@ class QueryToTermsArray
         # Remove quotes from query
         query.remove!(phrase.first)
 
-        # clean each phrase and split to arrary
-        strip_punctuation(phrase.first).split(' ')
+        # split each phrase to word arrary
+        phrase.first.split(' ')
       end
 
       # Remove punctuation from unquoted bits
@@ -56,6 +56,3 @@ class QueryToTermsArray
     query.gsub(/[^\w\s]/, '')
   end
 end
-
-# And can be used in controllers like this...
-# terms_array = QueryToTermsArray.new(query).term_array

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -7,11 +7,10 @@ class QueryToTermsArray
     query = query.upcase
 
     # if there are an even number of double quotes
-    if query.count('"') % 2 == 0
+    if query.count('"').even?
       quotes = extract_quoted_phrases(query)
 
       quotes = quotes.map do |phrase|
-
         # Remove quotes from query
         query.remove!(phrase.first)
 

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -1,4 +1,19 @@
+# Build an array of terms from a search query
+#
+# Capitalize all terms
+# Extract quoted phrases
+# Strip punctuation from unquoted phrases
+# Remove stopwords
+#
+#
+# @example
+# the french chef with Julia Child -> [["FRENCH"], ["CHEF"], ["JULIA"], ["CHILD"]]
+# "the french chef" with Julia Child -> [["THE", "FRENCH", "CHEF"], ["JULIA"], ["CHILD"]]
+
 class QueryToTermsArray
+  # @param [String] query The search query
+  #
+  # @return [Array<terms_array>] Returns an array of phrases, where each phrase is an array of terms in that phrase.
   attr_reader :query, :terms_array
 
   def initialize(query)
@@ -38,6 +53,8 @@ class QueryToTermsArray
 
   private
 
+  # Get cached list of stopwords from stopwords.txt
+  # @return [Array<String>] Returns array of stopwords
   def stopwords
     Rails.cache.fetch('stopwords') do
       sw = File.readlines(Rails.root.join('jetty', 'solr', 'blacklight-core', 'conf', 'stopwords.txt'), chomp: true).map(&:upcase)
@@ -47,14 +64,21 @@ class QueryToTermsArray
     end
   end
 
+  # Given an array of words, return the array without any stopwords
+  # @param [Array<String>] terms_array A word array from the query
   def remove_stopwords(terms_array)
     terms_array - stopwords
   end
 
+  # Given a query string, return an array of quoted phrases in that string
+  # @param [String] query The search query
   def extract_quoted_phrases(query)
+    # Match any double quote followed by 0 or more non double quote characters, followed by a double quote.
+    # This matches multiple sets of quoted phrases
     query.scan(/"([^"]*)"/)
   end
 
+  # Given a query string, return the string without punctuation
   def strip_punctuation(query)
     # Removes any non alphanumeric or space character
     query.gsub(/[^[:alpha:] ]/, '')

--- a/lib/query_to_terms_array.rb
+++ b/lib/query_to_terms_array.rb
@@ -1,26 +1,41 @@
-# Build an array of terms from a search query
+# Service class for converting a text query into a specially formatted array
+# of terms to be used in highlighting text in transcript snippets.
 #
-# Capitalize all terms
-# Extract quoted phrases
-# Strip punctuation from unquoted phrases
-# Remove stopwords
+# The class converts a text query into an array of terms according to the
+# following rules:
+# * Query terms not in double quotes are put into single-element arrays.
+# * Query terms within double quotes are put into an array where each element
+#   is a term within the double-quoted phrase.
+# * Stopwords are not removed from double-quoted phrases.
+# * Stopwords are removed from unquoted query terms.
+# * Special characters, in this case any non-alphanumeric, non-space character
+#   is removed.
 #
+# @see ./spec/lib/query_to_terms_array_spec.rb
+# @see SnippetHelper::Snippet - class that uses output from
+#   QueryToTermsArray#terms_array
 #
 # @example
-# the french chef with Julia Child -> [["FRENCH"], ["CHEF"], ["JULIA"], ["CHILD"]]
-# "the french chef" with Julia Child -> [["THE", "FRENCH", "CHEF"], ["JULIA"], ["CHILD"]]
-
+# query = "the french chef with Julia Child"
+# QueryToTermsArray.new(query).terms_array
+# => [["FRENCH"], ["CHEF"], ["JULIA"], ["CHILD"]]
+#
+# query = '"the french chef" with Julia Child'
+# QueryToTermsArray.new(query).terms_array
+# => [["THE", "FRENCH", "CHEF"], ["JULIA"], ["CHILD"]]
 class QueryToTermsArray
-  # @param [String] query The search query
-  #
-  # @return [Array<terms_array>] Returns an array of phrases, where each phrase is an array of terms in that phrase.
   attr_reader :query
 
+  # @param [String] query The search query
   def initialize(query)
     raise ArgumentError, "expected query to not be empty" if query.to_s.empty?
     @query = query.to_s.upcase
   end
 
+  # @return [Array<Array>] array where the first elements are arrays containing
+  #   each term from a quoted phrase, including stopwords, but excluding special
+  #   characters, followed by each unquoted term in the query, excluding both
+  #   stopwords and special chars.
   def terms_array
     quoted_terms_arrays + unquoted_terms_arrays
   end

--- a/spec/helpers/snippet_helper_spec.rb
+++ b/spec/helpers/snippet_helper_spec.rb
@@ -78,9 +78,13 @@ describe SnippetHelper do
   end
 
   describe 'query to terms array' do
-    # it 'removes punctuation from and capitalizes the user query' do
-    #   expect(clean_query_for_snippet(query_with_punctuation)).to eq(test_array)
-    # end
+    it 'removes punctuation from unquoted strings and capitalizes the user query' do
+      expect(QueryToTermsArray.new(%(`show, ^me % the ? "ice cream" $@*)).terms_array).to eq([%w(ICE CREAM), ["SHOW"], ["ME"]])
+    end
+
+    it 'leaves punctuation in quoted strings' do
+      expect(QueryToTermsArray.new(%(the lost year "1958-59")).terms_array).to eq([["1958-59"], ["LOST"], ["YEAR"]])
+    end
 
     it 'uses stopwords.txt to remove words not used in actual search' do
       expect(QueryToTermsArray.new(%(extremist is cheddar "president of the Eisenhower")).terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])

--- a/spec/helpers/snippet_helper_spec.rb
+++ b/spec/helpers/snippet_helper_spec.rb
@@ -77,28 +77,6 @@ describe SnippetHelper do
     end
   end
 
-  describe 'query to terms array' do
-    it 'removes punctuation from unquoted strings and capitalizes the user query' do
-      expect(QueryToTermsArray.new(%(`show_, ^me %+/- the ?   "ice cream" $@*)).terms_array).to eq([%w(ICE CREAM), ["SHOW"], ["ME"]])
-    end
-
-    it 'leaves punctuation in quoted strings' do
-      expect(QueryToTermsArray.new(%(the lost year "1958-59")).terms_array).to eq([["1958-59"], ["LOST"], ["YEAR"]])
-    end
-
-    it 'uses stopwords.txt to remove words not used in actual search' do
-      expect(QueryToTermsArray.new(%(extremist is cheddar "president of the Eisenhower")).terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
-    end
-
-    it 'matches multiple sets of double quoted phrases' do
-      expect(QueryToTermsArray.new(%("the french chef" with "Julia Child")).terms_array).to eq([%w(THE FRENCH CHEF), %w(JULIA CHILD)])
-    end
-
-    it 'strips all quotes if there are an odd number of quotation marks' do
-      expect(QueryToTermsArray.new(%("broken quotation" marks")).terms_array).to eq([["BROKEN"], ["QUOTATION"], ["MARKS"]])
-    end
-  end
-
   describe 'view snippet helpers' do
     it 'creates a timecode transcript snippet for the frontend' do
       expect(transcript_snippet(transcript_snippet_1.snippet, "Moving Image", transcript_snippet_1.url_at_timecode)).to eq(%(\n      <span class=\"index-data-title\">From Transcript</span>:\n      <p style=\"margin-top: 0;\"> FOR THIS 15TH ANNIVERSARY CELEBRATION AND DEDICATION CEREMONY IS MR GEORGE CAMPBELL CHAIRMAN OF THE <mark>ARKANSAS</mark> EDUCATIONAL TELEVISION COMMISSION GOOD AFTERNOON DISTINGUISHED GUESTS LADIES AND GENTLEMEN \n        \n        <a href=\"/catalog/cpb-aacip-111-21ghx7d6?term=ARKANSAS&proxy_start_time=50.24\">\n          <button type=\"button\" class=\"btn btn-default snippet-link\">Watch from here</button>\n        </a>\n      \n      </p>\n    ))

--- a/spec/helpers/snippet_helper_spec.rb
+++ b/spec/helpers/snippet_helper_spec.rb
@@ -83,7 +83,7 @@ describe SnippetHelper do
     # end
 
     it 'uses stopwords.txt to remove words not used in actual search' do
-      expect(QueryToTermsArray.new((%(extremist is cheddar "president of the Eisenhower"))).terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
+      expect(QueryToTermsArray.new(%(extremist is cheddar "president of the Eisenhower")).terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
     end
   end
 

--- a/spec/helpers/snippet_helper_spec.rb
+++ b/spec/helpers/snippet_helper_spec.rb
@@ -83,7 +83,7 @@ describe SnippetHelper do
     # end
 
     it 'uses stopwords.txt to remove words not used in actual search' do
-      expect(query_to_terms_array(%(extremist is cheddar "president of the Eisenhower"))).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
+      expect(QueryToTermsArray.new((%(extremist is cheddar "president of the Eisenhower"))).terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
     end
   end
 

--- a/spec/helpers/snippet_helper_spec.rb
+++ b/spec/helpers/snippet_helper_spec.rb
@@ -79,7 +79,7 @@ describe SnippetHelper do
 
   describe 'query to terms array' do
     it 'removes punctuation from unquoted strings and capitalizes the user query' do
-      expect(QueryToTermsArray.new(%(`show, ^me % the ? "ice cream" $@*)).terms_array).to eq([%w(ICE CREAM), ["SHOW"], ["ME"]])
+      expect(QueryToTermsArray.new(%(`show_, ^me %+/- the ?   "ice cream" $@*)).terms_array).to eq([%w(ICE CREAM), ["SHOW"], ["ME"]])
     end
 
     it 'leaves punctuation in quoted strings' do
@@ -88,6 +88,14 @@ describe SnippetHelper do
 
     it 'uses stopwords.txt to remove words not used in actual search' do
       expect(QueryToTermsArray.new(%(extremist is cheddar "president of the Eisenhower")).terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
+    end
+
+    it 'matches multiple sets of double quoted phrases' do
+      expect(QueryToTermsArray.new(%("the french chef" with "Julia Child")).terms_array).to eq([%w(THE FRENCH CHEF), %w(JULIA CHILD)])
+    end
+
+    it 'strips all quotes if there are an odd number of quotation marks' do
+      expect(QueryToTermsArray.new(%("broken quotation" marks")).terms_array).to eq([["BROKEN"], ["QUOTATION"], ["MARKS"]])
     end
   end
 

--- a/spec/lib/query_to_terms_array_spec.rb
+++ b/spec/lib/query_to_terms_array_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe QueryToTermsArray do
         let(:query) { '"quoted phrase one" "another quoted phrase"' }
         it 'returns an array where each element is an array containing the ' \
            'terms from quoted phrases' do
-          expect(terms_array).to eq [%W(QUOTED PHRASE ONE), %W(ANOTHER QUOTED PHRASE)]
+          expect(terms_array).to eq [%w(QUOTED PHRASE ONE), %w(ANOTHER QUOTED PHRASE)]
         end
       end
 

--- a/spec/lib/query_to_terms_array_spec.rb
+++ b/spec/lib/query_to_terms_array_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe QueryToTermsArray do
   describe '#terms_array' do
-
     let(:terms_array) { QueryToTermsArray.new(query).terms_array }
 
     context 'when query is empty' do

--- a/spec/lib/query_to_terms_array_spec.rb
+++ b/spec/lib/query_to_terms_array_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe QueryToTermsArray do
       end
 
       context 'and when query contains only a single quoted phrase' do
-        let(:query) { '"quoted phrase"'}
+        let(:query) { '"quoted phrase"' }
         it 'returns an array where first and only element is an array of ' \
            'terms from the quoted phrase' do
           expect(terms_array).to eq [%w(QUOTED PHRASE)]

--- a/spec/lib/query_to_terms_array_spec.rb
+++ b/spec/lib/query_to_terms_array_spec.rb
@@ -80,6 +80,13 @@ RSpec.describe QueryToTermsArray do
           expect(terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
         end
       end
+
+      context 'when query contains numbers' do
+        let(:query) { %(lost year "1958-59" 1960) }
+        it 'leaves numbers in quoted and unquoted terms' do
+          expect(terms_array).to eq([%w(1958 59), ["LOST"], ["YEAR"], ["1960"]])
+        end
+      end
     end
   end
 end

--- a/spec/lib/query_to_terms_array_spec.rb
+++ b/spec/lib/query_to_terms_array_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe QueryToTermsArray do
 
     context 'when query is empty' do
       let(:query) { '' }
-      it 'raises an error' do
-        expect { terms_array }.to raise_error ArgumentError
+      it 'returns an empty array' do
+        expect(terms_array).to eq []
       end
     end
 
     context 'when query is not empty' do
       context 'and when query contains no quoted terms' do
-        let(:query) { 'a query with no quoted terms' }
+        let(:query) { 'query without quoted terms' }
         it 'returns an array where each element is a single-element array ' \
            'containing each unquoted term from the query' do
-          expect(terms_array).to eq [["QUERY"], ["QUOTED"], ["TERMS"]]
+          expect(terms_array).to eq [["QUERY"], ["WITHOUT"], ["QUOTED"], ["TERMS"]]
         end
 
         context 'and query contains punctuation' do
-          let(:query) { %(`show_, ^me %+/- the ? $@*) }
+          let(:query) { %(`show_, ^me %+/- ice ? $@* cream}) }
           it 'returns an array containing each term without punctuation' do
-            expect(terms_array).to eq [["SHOW"], ["ME"]]
+            expect(terms_array).to eq [["SHOW"], ["ME"], ["ICE"], ["CREAM"]]
           end
         end
       end
@@ -32,7 +32,7 @@ RSpec.describe QueryToTermsArray do
         let(:query) { '"quoted phrase"'}
         it 'returns an array where first and only element is an array of ' \
            'terms from the quoted phrase' do
-          expect(terms_array).to eq [["QUOTED", "PHRASE"]]
+          expect(terms_array).to eq [%w(QUOTED PHRASE)]
         end
       end
 
@@ -41,7 +41,7 @@ RSpec.describe QueryToTermsArray do
         it 'returns an array where the first element is an array containing ' \
            'each term from the quoted phrase, and the remaining elements are ' \
            'single-element arrays containing the unquoted terms from the query' do
-          expect(terms_array).to eq [["QUOTED", "PHRASE"], ['UNQUOTED'], ['STUFF']]
+          expect(terms_array).to eq [%w(QUOTED PHRASE), ['UNQUOTED'], ['STUFF']]
         end
       end
 
@@ -49,7 +49,14 @@ RSpec.describe QueryToTermsArray do
         let(:query) { '"quoted phrase one" "another quoted phrase"' }
         it 'returns an array where each element is an array containing the ' \
            'terms from quoted phrases' do
-          expect(terms_array).to eq [["QUOTED", "PHRASE", "ONE"], ["ANOTHER", "QUOTED", "PHRASE"]]
+          expect(terms_array).to eq [%W(QUOTED PHRASE ONE), %W(ANOTHER QUOTED PHRASE)]
+        end
+      end
+
+      context 'when there are an odd number of quotation marks' do
+        let(:query) { %("broken quotation" marks") }
+        it 'ignores the last odd quotation mark' do
+          expect(terms_array).to eq([%w(BROKEN QUOTATION), ["MARKS"]])
         end
       end
 
@@ -57,7 +64,21 @@ RSpec.describe QueryToTermsArray do
         let(:query) { %("This` is_, a^quoted %+/- phrase ? $@*") }
         it 'returns an array where the elements are arrays of terms from the ' \
            'quoted phrase with all non-alphanumeric chars removed' do
-          expect(terms_array).to eq [["THIS", "IS", "A", "QUOTED", "PHRASE"]]
+          expect(terms_array).to eq [%w(THIS IS A QUOTED PHRASE)]
+        end
+      end
+
+      context 'when query contains an unquoted stopword' do
+        let(:query) { %(a search with no stopworda or stopwordb) }
+        it 'uses stopwords.txt to remove words not used in actual search' do
+          expect(terms_array).to eq([%w(SEARCH)])
+        end
+      end
+
+      context 'when query contains a quoted stopword' do
+        let(:query) { %(extremist is cheddar "president of the Eisenhower") }
+        it 'preserves the stopword in the search' do
+          expect(terms_array).to eq([%w(PRESIDENT OF THE EISENHOWER), ["EXTREMIST"], ["CHEDDAR"]])
         end
       end
     end

--- a/spec/lib/query_to_terms_array_spec.rb
+++ b/spec/lib/query_to_terms_array_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe QueryToTermsArray do
+  describe '#terms_array' do
+
+    let(:terms_array) { QueryToTermsArray.new(query).terms_array }
+
+    context 'when query is empty' do
+      let(:query) { '' }
+      it 'raises an error' do
+        expect { terms_array }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when query is not empty' do
+      context 'and when query contains no quoted terms' do
+        let(:query) { 'a query with no quoted terms' }
+        it 'returns an array where each element is a single-element array ' \
+           'containing each unquoted term from the query' do
+          expect(terms_array).to eq [["QUERY"], ["QUOTED"], ["TERMS"]]
+        end
+
+        context 'and query contains punctuation' do
+          let(:query) { %(`show_, ^me %+/- the ? $@*) }
+          it 'returns an array containing each term without punctuation' do
+            expect(terms_array).to eq [["SHOW"], ["ME"]]
+          end
+        end
+      end
+
+      context 'and when query contains only a single quoted phrase' do
+        let(:query) { '"quoted phrase"'}
+        it 'returns an array where first and only element is an array of ' \
+           'terms from the quoted phrase' do
+          expect(terms_array).to eq [["QUOTED", "PHRASE"]]
+        end
+      end
+
+      context 'when query contains a mix of unquoted terms and quoted phrases' do
+        let(:query) { 'unquoted stuff "quoted phrase"' }
+        it 'returns an array where the first element is an array containing ' \
+           'each term from the quoted phrase, and the remaining elements are ' \
+           'single-element arrays containing the unquoted terms from the query' do
+          expect(terms_array).to eq [["QUOTED", "PHRASE"], ['UNQUOTED'], ['STUFF']]
+        end
+      end
+
+      context 'when query contains multiple quoted phrases' do
+        let(:query) { '"quoted phrase one" "another quoted phrase"' }
+        it 'returns an array where each element is an array containing the ' \
+           'terms from quoted phrases' do
+          expect(terms_array).to eq [["QUOTED", "PHRASE", "ONE"], ["ANOTHER", "QUOTED", "PHRASE"]]
+        end
+      end
+
+      context 'when query contains a quoted phrase with non-alphanumeric characters' do
+        let(:query) { %("This` is_, a^quoted %+/- phrase ? $@*") }
+        it 'returns an array where the elements are arrays of terms from the ' \
+           'quoted phrase with all non-alphanumeric chars removed' do
+          expect(terms_array).to eq [["THIS", "IS", "A", "QUOTED", "PHRASE"]]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Quotes
Refactors `ApplicationHelper::query_to_terms_array` to `lib/query_to_terms_array.rb`

Better handles quoted searches and edge cases.

- Splits into sub-functions:
  - `terms_array`
    - The final array of search terms
  - `stopwords`
    - Get stopwords from `stopwords.txt`
    - Store in Rails cache
  - `quoted_phrases`
    - Returns list of phrases between two quotation marks as `Array<String>`
  - `quoted_terms_arrays`
    - Returns terms_array of quoted phrases as `Array<Array<String>>`
  - `unquoted_query`
    - Returns `String` of original query, minus quoted phrases
  - `unquoted_terms`
    - Returns `Array<Array<String>>` of all unquoted terms from query, minus stopwords
  - `strip_special_chars`
    - Removes all non-alphanumeric characters
- Better documentation of steps
- Only parse quotes if even number of `"`
  - Queries with an odd number get stripped of punctuation
  - Fixes 500 error from solr


## `app/views/catalog/index.html.erb`
- Adds ``` ` ` ``` (backtick) escaping 
  - Allows all `"` and `'` characters
- Uses `raw()` formatting

## `specs/lib/query_to_terms_array_spec.rb`
- Adds unit tests to ensure full coverage of functionality
  - Empty query returns `[]`
  - Capitalizes the user query
  - Removes punctuation from quoted and unquoted strings and
  - Leaves punctuation in quoted strings
  - Matches multiple sets of double quoted phrases
  - Strips all quotes if there are an odd number of quotation marks

Closes #2453