### PR TITLE
🔧 Fix syntax for new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Because_Done.yml
+++ b/.github/ISSUE_TEMPLATE/Because_Done.yml
@@ -1,4 +1,4 @@
-name: Because / Done when
+name: ':clipboard: Because / Done when'
 description: Standard issue template, neither a bug nor a feature.
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
-name: Bug report
+name: ':bug: Bug Report'
 description: Report a bug to help us improve
-title: ''
 labels: Bug
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
-name: Feature request
+name: ':bulb: Feature Request'
 description: Suggest an idea for this project
-title: ''
 body:
   - type: markdown
     attributes:
@@ -11,8 +10,8 @@ body:
 
   - type: textarea
     id: summary
-    description: ':pencil2: Briefly summarize your feature request'
     attributes:
+      description: ':pencil2: Briefly summarize your feature request'
       label: Summary
       placeholder: |
         As a [user]
@@ -21,21 +20,21 @@ body:
 
   - type: textarea
     id: related
-    description: ':grey_question: Is this issue related to other existing issues? Please link them below'
     attributes:
+      description: ':grey_question: Is this issue related to other existing issues? Please link them below'
       label: Related
       placeholder: Fixes [link to existing issue]
 
   - type: textarea
     id: alternatives
-    description: ':part_alternation_mark: Describe alternatives you have considered'
     attributes:
+      description: ':part_alternation_mark: Describe alternatives you have considered'
       label: Alternatives
       placeholder: We could also ...
 
   - type: textarea
     id: context
-    description: ':information_desk_person: Add any other context or screenshots about the feature request here.'
     attributes:
+      description: ':information_desk_person: Add any other context or screenshots about the feature request here.'
       label: Additional context
       placeholder: Due date, required for, blocked by ...


### PR DESCRIPTION
# Issue templates
Fixes broken templates
- Title should not be blank
  - Removed
- `description` should be under `attributes`