### PR TITLE
Ignores more logs and prevents log crawling by bots

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -70,7 +70,7 @@ class LogsController < ApplicationController
     # list of Rails logs for test, development, and production environments.
     # @return [Array<string>]
     def ignore
-      @ignore ||= ['test.log', 'development.log', 'production.log']
+      @ignore ||= ['test.log*', 'development.log*', 'production.log*']
     end
 
     def ignored?(filename)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,4 @@
 User-agent: *
 Disallow: /catalog
 Allow: /catalog/
+Disallow: /logs


### PR DESCRIPTION
* Adds glob patterns to ignore Rails logs that have been rolled.
* Add /logs to robots.txt to prevent search engine indexing.