### PR TITLE
Adds American Samoa to state abbreviations

### DIFF
--- a/config/states.yml
+++ b/config/states.yml
@@ -154,3 +154,6 @@
 
 - state: Guam
   abbreviation: GU
+ 
+- state: American Samoa
+  abbreviation: AS


### PR DESCRIPTION
Because without it, ingest fails. Of course. If a record is part of a special collection that has a state or territory that is not represented in the states.yml file, then the ingester will choke when trying to validate -- which is really dumb, but that's what happens.