### PR TITLE
Handle json-breaking double quotes in pbcore values in JSON API

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -45,13 +45,12 @@ class ApiController < ApplicationController
       end
 
       format.json do
-        pbcore_xml_to_json_xsl_doc = Nokogiri::XSLT(File.read('./lib/pbcore_xml_to_json.xsl'))
+        # escape double quotes (because they may appear in node values)
+        xml = xml.gsub(%(\"),%(\\\"))
+
+        json = pbcore_xml_to_json_xsl_doc.transform(Nokogiri::XML(xml))
         render json: JSON.pretty_generate(
-          JSON.parse(
-            pbcore_xml_to_json_xsl_doc.transform(
-              Nokogiri::XML(xml)
-            )
-          )
+          JSON.parse(json)
         )
       end
     end
@@ -73,5 +72,12 @@ class ApiController < ApplicationController
 
   def render_no_transcript_content
     render json: { status: '404 Not Found', code: '404', message: 'This transcript is not currently available' }, status: :not_found
+  end
+
+  private
+  def pbcore_xml_to_json_xsl_doc
+    Rails.cache.fetch("pbcore_xml_to_json_xsl_doc") do
+      return Nokogiri::XSLT(File.read('./lib/pbcore_xml_to_json.xsl'))
+    end
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -75,7 +75,7 @@ class ApiController < ApplicationController
   end
 
   private
-  
+
   def pbcore_xml_to_json_xsl_doc
     Rails.cache.fetch("pbcore_xml_to_json_xsl_doc") do
       return Nokogiri::XSLT(File.read('./lib/pbcore_xml_to_json.xsl'))

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -38,10 +38,10 @@ class ApiController < ApplicationController
   def show
     @solr = Solr.instance.connect
     data = @solr.get('select', params: { q: "id:#{params[:id]}", fl: 'xml' })
-    
+
     return render_not_found(params[:id]) unless data['response']['docs'] && data['response']['docs'][0]
     xml = data['response']['docs'][0]['xml']
-    
+
     respond_to do |format|
       format.xml do
         render text: xml

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -38,7 +38,10 @@ class ApiController < ApplicationController
   def show
     @solr = Solr.instance.connect
     data = @solr.get('select', params: { q: "id:#{params[:id]}", fl: 'xml' })
+    
+    return render_not_found(params[:id]) unless data['response']['docs'] && data['response']['docs'][0]
     xml = data['response']['docs'][0]['xml']
+    
     respond_to do |format|
       format.xml do
         render text: xml
@@ -72,6 +75,10 @@ class ApiController < ApplicationController
 
   def render_no_transcript_content
     render json: { status: '404 Not Found', code: '404', message: 'This transcript is not currently available' }, status: :not_found
+  end
+
+  def render_not_found(guid)
+    render json: { status: '404 Not Found', code: '404', message: "Record #{guid} not found" }, status: :not_found
   end
 
   private

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -46,7 +46,7 @@ class ApiController < ApplicationController
 
       format.json do
         # escape double quotes (because they may appear in node values)
-        xml = xml.gsub(%(\"),%(\\\"))
+        xml = xml.gsub(%(\"), %(\\\"))
 
         json = pbcore_xml_to_json_xsl_doc.transform(Nokogiri::XML(xml))
         render json: JSON.pretty_generate(
@@ -75,6 +75,7 @@ class ApiController < ApplicationController
   end
 
   private
+  
   def pbcore_xml_to_json_xsl_doc
     Rails.cache.fetch("pbcore_xml_to_json_xsl_doc") do
       return Nokogiri::XSLT(File.read('./lib/pbcore_xml_to_json.xsl'))


### PR DESCRIPTION
'cache pbcore xsl for json api, re-escape double quotes in xml before json transformation'