### PR TITLE
📟 API endpoint search for old-style IDs

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -37,7 +37,11 @@ class ApiController < ApplicationController
 
   def show
     @solr = Solr.instance.connect
-    data = @solr.get('select', params: { q: "id:#{params[:id]}", fl: 'xml' })
+    # Replace the delimiter at the end fo the AAPB ID prefix with a single character wildcard
+    # to return any docs that are indexed with old-style ID's, having a slash, or sometimes an underscore
+    # instead of a dash. Eventually, all records should have new-style IDs with the dashes. Until then, this.
+    id = params[:id].sub(/cpb-aacip./, "cpb-aacip?")
+    data = @solr.get('select', params: { q: "id:#{id}", fl: 'xml' })
 
     return render_not_found(params[:id]) unless data['response']['docs'] && data['response']['docs'][0]
     xml = data['response']['docs'][0]['xml']

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -236,7 +236,9 @@ class CatalogController < ApplicationController
 
   def show
     # From BlacklightGUIDFetcher
-    @response, @document = fetch_from_solr(params['id'])
+    id = params[:id].sub(/cpb-aacip./, "cpb-aacip?")
+    @response, @document = fetch_from_solr(id)
+    
     # If we didn't end up getting a @document, 404
     raise ActionController::RoutingError.new('Not Found') unless @document
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -238,7 +238,7 @@ class CatalogController < ApplicationController
     # From BlacklightGUIDFetcher
     id = params[:id].sub(/cpb-aacip./, "cpb-aacip?")
     @response, @document = fetch_from_solr(id)
-    
+
     # If we didn't end up getting a @document, 404
     raise ActionController::RoutingError.new('Not Found') unless @document
 


### PR DESCRIPTION
Replaces:
- `cpb-aacip-`
- `cpb-aacip/`
- `cpb-aacip_`

with: `cpb-aacip?`

so that all ID styles can be returned when querying on ID.

Closes #2773
Closes #2827