### PR TITLE
📌 Pin CI runners to ubuntu 22.04

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   rubocop:
     name: 🤖 Check code style with Rubocop
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 📰 Checkout code

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   specs:
     name: 📋 Run Specs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 📰 Checkout code


### PR DESCRIPTION
# Ubuntu
Pins the runner image to `ubuntu-22.04`

`ubuntu-latest` began failing due to missing `sqlite3.h` header. `ubuntu-22.04` builds `sqlite3` successfully, as before.