### PR TITLE
Add CORS headers explicitly for IIIF requests

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -283,6 +283,7 @@ class CatalogController < ApplicationController
         render text: PBCorePresenter.new(xml).to_mods
       end
       format.iiif do
+        allow_cors!
         render json: PBCorePresenter.new(xml).iiif_manifest
       end
     end
@@ -340,5 +341,12 @@ class CatalogController < ApplicationController
         nil
       end
     end
+  end
+
+  def allow_cors!
+    headers['Access-Control-Allow-Origin'] = '*'
+    headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
+    headers['Access-Control-Request-Method'] = '*'
+    headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, Authorization'
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module Xyz
       end
       allow do
         origins '*'
-        resource '/catalog/*.iiif', headers: :any, methods: [:get, :options]
+        resource '/catalog/*.iiif', headers: :any, methods: [:get, :options], expose: ['Access-Control-Allow-Origin']
       end
     end
 

--- a/spec/cors/cors_spec.rb
+++ b/spec/cors/cors_spec.rb
@@ -1,4 +1,5 @@
 require 'curl'
+require_relative '../../scripts/lib/pb_core_ingester'
 
 describe 'CORS' do
   before(:all) do


### PR DESCRIPTION
Adds Access-Control-Allow-Origin as an exposed response header to Rack::CORS config.

Also,
* Requires dependencies explicitly in CORS spec to allow running in alone.