### PR TITLE
Fixes regex to match beginnig of IP address

### DIFF
--- a/scripts/lib/apache_log_parser.rb
+++ b/scripts/lib/apache_log_parser.rb
@@ -120,7 +120,7 @@ class BadBotConfigLines
     indent + ips.map do |ip|
       ip += '.' if ip.count('.') < 3
       ip.gsub!('.', '\.')
-      "SetEnvIfNoCase Remote_Addr \"#{ip}\" bad_bot"
+      "SetEnvIfNoCase Remote_Addr \"^#{ip}\" bad_bot"
     end.join("\n#{indent}")
   end
 end


### PR DESCRIPTION
The BadBotConfigLine class spits out sample apache configuration based to block certain IP address blocks based on their frequency in the apache log. The regex in the script was erroneously matching octet pairs to any part of the clients IP to flag it as a bad bot. This PR fixes the regex to only match the beginning

Fixes #2899