### PR TITLE
CMLess parser

### DIFF
--- a/app/views/special_collections/to-the-moon.md
+++ b/app/views/special_collections/to-the-moon.md
@@ -1,4 +1,3 @@
-
 # To the Moon Interviews
 
 ## Thumbnail

--- a/exhibits.ipynb
+++ b/exhibits.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "583b6e37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cmless import parse_cmless, parse_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12c81f21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# c = parse_cmless('app/views/special_collections/zoom.md')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f17484cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collections = parse_dir('app/views/special_collections')\n",
+    "collections['zoom']"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# CMLess parser
Improved python CMLess parser

- [x] Improved error handling
- [x] `parse_cmless` now accepts filepath instead of md string
- [x] Generic directory parser
- [x] Org example
- [/] Special Collections