### PR TITLE
Move clipping slider underneath 10s skip buttons on show page

### DIFF
--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -51,12 +51,6 @@
 
         <div class="row">
           <div class="col-md-12">
-            <%= render partial: 'time_range' %>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-12">
 
             <button id="skip-back" class="player-button skip-button">◀◀ 10s</button>
             <button id="skip-forward" class="player-button skip-button">10s ▶▶</button>
@@ -74,6 +68,12 @@
           </div>
         </div>
 
+        <div class="row">
+          <div class="col-md-12">
+            <%= render partial: 'time_range' %>
+          </div>
+        </div>
+        
         <%= render partial: 'share_modal' %>
 
       </div>


### PR DESCRIPTION
Move the clip slider underneath the 10s skip buttons, so toggle switch doesn't pop around when toggled.