### PR TITLE
allows guids with no sony ci ID but with Private LUA

### DIFF
--- a/app/models/pb_core_presenter.rb
+++ b/app/models/pb_core_presenter.rb
@@ -292,7 +292,6 @@ class PBCorePresenter
       access_levels = xpaths('/*/pbcoreAnnotation[@annotationType="Level of User Access"]')
       raise('Should have at most 1 "Level of User Access" annotation') if access_levels.count > 1
       raise('Should have "Level of User Access" annotation if digitized') if digitized? && access_levels.count == 0
-      raise('Should not have "Level of User Access" annotation if not digitized') if !digitized? && access_levels.count != 0
       access_levels.first # Returns nil for non-digitized
     end
   end

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -77,14 +77,6 @@ describe 'Validated and plain PBCore' do
           raise_error(/Should have "Level of User Access" annotation if digitized/))
       end
 
-      it 'rejects undigitized w/ "Level of User Access"' do
-        invalid_pbcore = pbc_xml.gsub(
-          /<pbcoreIdentifier source='Sony Ci'>[^<]+<[^>]+>/,
-          '')
-        expect { ValidatedPBCore.new(invalid_pbcore) }.to(
-          raise_error(/Should not have "Level of User Access" annotation if not digitized/))
-      end
-
       it 'rejects "Outside URL" if not explicitly ORR' do
         invalid_pbcore = pbc_xml.gsub( # First make it un-digitized
           /<pbcoreIdentifier source='Sony Ci'>[^<]+<[^>]+>/,


### PR DESCRIPTION
Allows guids to be pushed to AAPB even though they lack a sony ci ID and have the LUA = "Private". This lets us provide metadata only access to Sesame Street content.