### PR TITLE
Private lua statement

### DIFF
--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -119,9 +119,8 @@
     not yet been reviewed for copyright or privacy issues. For information about
     on location research, <a href="/on-location">click here</a>.
   <% elsif @pbcore.private? %>
-    Please note: This content is only available at the Library of Congress due
-    to copyright restrictions or privacy concerns. For information about on
-    location research, <a href="/on-location">click here</a>.
+    Please note: This content is not available due
+    to copyright restrictions or privacy concerns.
   <% elsif !@pbcore.digitized? && !@pbcore.contributing_organization_objects.empty? %>
     This content is not available. Please contact the contributing organization(s) listed below.
   <% elsif !@pbcore.digitized? && @pbcore.contributing_organization_objects.empty? %>

--- a/app/views/embed/show.html.erb
+++ b/app/views/embed/show.html.erb
@@ -71,9 +71,8 @@
     not yet been reviewed for copyright or privacy issues. For information about
     on location research, <a target="_blank" href="/on-location">click here</a>.
   <% elsif @pbcore.private? %>
-    Please note: This content is only available at the Library of Congress due
-    to copyright restrictions or privacy concerns. For information about on
-    location research, <a target="_blank" href="/on-location">click here</a>.
+    Please note: This content is not available due
+    to copyright restrictions or privacy concerns.
   <% elsif !@pbcore.digitized? && !@pbcore.contributing_organization_objects.empty? %>
     This content is not available. Please contact the contributing organization(s) listed below.
   <% elsif !@pbcore.digitized? && @pbcore.contributing_organization_objects.empty? %>

--- a/spec/features/embed_spec.rb
+++ b/spec/features/embed_spec.rb
@@ -51,13 +51,7 @@ describe 'Embed' do
     before { visit 'embed/cpb-aacip_moving-image-private' }
     it 'does not show the video player' do
       expect(page).not_to have_css('video')
-      expect(page).to have_content "This content is only available at the Library of Congress"
-    end
-
-    # When embedding, links back to AAPB need to open in a new window
-    # otherwise we get an error in the iframe.
-    it 'has links with the expected target attribute' do
-      expect(page.find_link(href: /.*\/on-location/)[:target]).to eq("_blank")
+      expect(page).to have_content "Please note: This content is not available due to copyright restrictions or privacy concerns."
     end
   end
 end


### PR DESCRIPTION
Private items currently state you can stream them onsite at Library of Congress. However, we'd like to adjust the definition of private as not allowing streaming anywhere. The logic is already set up to not stream at LOC, but the statement needs to be updated to reflect that.