### PR TITLE
Bot query block

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -304,11 +304,11 @@ class CatalogController < ApplicationController
   end
 
   def reject_abusive_queries
-  query_string = request.query_string
+    query_string = request.query_string
     
     if query_string.length > 1000 || query_string.scan(/\bOR\b/).count > 10
       Rails.logger.warn("Rejected abusive catalog query from #{request.remote_ip}: #{query_string.truncate(200)}")
-      render plain: "Bad Request", status: :bad_request
+      render plain: "Bad Request: please submit a valid query", status: :bad_request
     end
   end
   

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,7 +4,7 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
   include ApplicationHelper
   include BlacklightGUIDFetcher
-  
+
   before_action :reject_abusive_queries, only: [:index]
   before_action :require_turnstile, only: [:index]
 
@@ -305,13 +305,13 @@ class CatalogController < ApplicationController
 
   def reject_abusive_queries
     query_string = request.query_string
-    
+
     if query_string.length > 1000 || query_string.scan(/\bOR\b/).count > 10
       Rails.logger.warn("Rejected abusive catalog query from #{request.remote_ip}: #{query_string.truncate(200)}")
       render plain: "Bad Request: please submit a valid query", status: :bad_request
     end
   end
-  
+
   def redirect_to_proxy_start_time?(pbcore, params)
     pbcore.proxy_start_time && params["proxy_start_time"].nil? && !media_start_time?(params)
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,7 +4,8 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
   include ApplicationHelper
   include BlacklightGUIDFetcher
-
+  
+  before_action :reject_abusive_queries, only: [:index]
   before_action :require_turnstile, only: [:index]
 
   # allows usage of default_processor_chain v
@@ -302,6 +303,15 @@ class CatalogController < ApplicationController
     redirect_to turnstile_challenge_path(return_to: request.fullpath)
   end
 
+  def reject_abusive_queries
+  query_string = request.query_string
+    
+    if query_string.length > 1000 || query_string.scan(/\bOR\b/).count > 10
+      Rails.logger.warn("Rejected abusive catalog query from #{request.remote_ip}: #{query_string.truncate(200)}")
+      render plain: "Bad Request", status: :bad_request
+    end
+  end
+  
   def redirect_to_proxy_start_time?(pbcore, params)
     pbcore.proxy_start_time && params["proxy_start_time"].nil? && !media_start_time?(params)
   end

--- a/app/controllers/turnstile_controller.rb
+++ b/app/controllers/turnstile_controller.rb
@@ -24,7 +24,7 @@ class TurnstileController < ApplicationController
       # Server sets the cookie in the response
       cookies.encrypted[:turnstile_verified] = {
         value: true,
-        expires: 24.hours.from_now,
+        expires: 2.hours.from_now,
         secure: Rails.env.production?,
         httponly: true,
         same_site: :strict


### PR DESCRIPTION
Adds a block to any queries with strings greater than 1000 characters, or queries with more than 10 'OR' statements. Leads to Bad Request page.

Also sets cookie expiration to 2 hours, as opposed to 24.