### PR TITLE
Add Monitor Radio collection overview

### DIFF
--- a/app/views/special_collections/monitor.md
+++ b/app/views/special_collections/monitor.md
@@ -28,12 +28,12 @@ Monitor Radio won multiple awards for journalistic excellence, such as first pla
 
 ## Featured
 
-[![AIDS, Part I](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-08bb9719d4c)
-[![Chernobyl Disaster](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-fbc75b3c14f)
-[![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-9cf8e5bfd21)
-[![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-882295338b6)
-[![Bosnian War](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-35d0786be67)
-[![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-d199684e32a ) 
+[![AIDS, Part I](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-7.png)](/catalog/cpb-aacip-08bb9719d4c)
+[![Chernobyl Disaster](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-7.png)](/catalog/cpb-aacip-fbc75b3c14f)
+[![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-7.png)](/catalog/cpb-aacip-9cf8e5bfd21)
+[![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-7.png)](/catalog/cpb-aacip-882295338b6)
+[![Bosnian War](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-7.png)](/catalog/cpb-aacip-35d0786be67)
+[![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-7.png)](/catalog/cpb-aacip-d199684e32a ) 
 
 ## Resources
 

--- a/app/views/special_collections/monitor.md
+++ b/app/views/special_collections/monitor.md
@@ -28,12 +28,12 @@ Monitor Radio won multiple awards for journalistic excellence, such as first pla
 
 ## Featured
 
-[![AIDS, Part I](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-08bb9719d4c)
-[![Chernobyl Disaster](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-fbc75b3c14f)
-[![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-9cf8e5bfd21)
-[![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-882295338b6)
-[![Bosnian War](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-35d0786be67)
-[![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-d199684e32a ) 
+[![AIDS, Part I](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-08bb9719d4c)
+[![Chernobyl Disaster](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-fbc75b3c14f)
+[![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-9cf8e5bfd21)
+[![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-882295338b6)
+[![Bosnian War](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-35d0786be67)
+[![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-6.png)](/catalog/cpb-aacip-d199684e32a ) 
 
 ## Resources
 

--- a/app/views/special_collections/monitor.md
+++ b/app/views/special_collections/monitor.md
@@ -1,0 +1,58 @@
+# Monitor Radio
+
+## Thumbnail
+
+![Monitor Radio logo featuring a globe against a white background and the words "Monitor Radio: A Service of the Christian Science Monitor"](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-thumbnail-upscaled.png "Monitor Radio logo") 
+
+## Summary 
+
+The Monitor Radio collection encompasses over twenty years of broadcasts from [*The Christian Science Monitor*](https://www.csmonitor.com/), an editorially independent journalistic enterprise of the First Church of Christ, Scientist, in Boston. Comprising nearly 7,000 programs from 1977 to 1997, the collection consists predominantly of episodes of *Monitor Radio* (1984–1997), a news, arts, and culture magazine distributed by public media. In addition to early-morning, daily, and weekend editions of this series, the collection also includes broadcasts from *Monitor News Service* (1977–1983), a precursor to *Monitor Radio*, and *Monitor Radio Conversations* (1985), featuring interviews with thought leaders, political pundits, and public figures.
+
+In keeping with *The Christian Science Monitor*’s editorial principles, *Monitor Radio* was noteworthy for its objectivity and eschewal of sensationalism. International in focus, *Monitor Radio* documented many of the most pivotal events of the second half of the Cold War. These include the [Soviet-Afghan War](/catalog/cpb-aacip-46e02e07ed9), the [Tiananmen Square protests and massacre](/catalog/cpb-aacip-415338deadc), [the fall of the Berlin Wall](/catalog/cpb-aacip-09795e15bac), and the [1991 Soviet Coup](/catalog/cpb-aacip-91743e94317).
+
+Several episodes reflect on recent history. For example, in 1989, *Monitor Radio* aired a report on the partial meltdown of the [Three Mile Island nuclear plant](https://americanarchive.org/catalog/cpb-aacip-0fd550a4575) in Londonderry Township, Pennsylvania, a decade earlier. Similarly, on the ten-year anniversary of the [Chernobyl nuclear disaster](https://americanarchive.org/catalog/cpb-aacip-292e394e53e) in northern Ukraine, *Monitor Radio* featured a story on the incident and its lasting effects on survivors and the environment. On the fortieth anniversary of the founding of Israel, *Monitor Radio* offered an [objective account](https://americanarchive.org/catalog/cpb-aacip-306da3ceeec) of the history of the country and present-day challenges, and on December 26, 1991, the [program looked back](https://americanarchive.org/catalog/cpb-aacip-9cf8e5bfd21) on the Soviet Union’s final year on the day it was formally dissolved.
+
+*Monitor Radio* not only reported on major news stories; it also explored their complexities. For instance, when [Nelson Mandela was released from prison](https://americanarchive.org/catalog/cpb-aacip-9f46aa1937b) on February 11, 1990, *Monitor Radio* reported on his first public comments following his 27-year imprisonment. It then delved deeper into the topic of the anti-apartheid movement, featuring a story on the impact of US-imposed economic sanctions on South Africa and a profile of Mandela titled “Nelson Mandela: The Man Behind the Myth.”
+
+In addition to reporting on international issues, *Monitor Radio* also covered US news and politics, such as efforts to pass the [North American Free Trade Agreement](https://americanarchive.org/catalog/cpb-aacip-dd58db9823f), the [Oklahoma City bombing](https://americanarchive.org/catalog/cpb-aacip-1f2d43a501a), and the [O.J. Simpson trial](https://americanarchive.org/catalog/cpb-aacip-2cc808c7c83). The series documented the United States’ [entry into the Gulf War](https://americanarchive.org/catalog/cpb-aacip-6e58c05ba9e), as well as major scientific breakthroughs, including the [launch of the Hubble Space Telescope](https://americanarchive.org/catalog/cpb-aacip-050b385deea) and the [cloning of Dolly the sheep](https://americanarchive.org/catalog/cpb-aacip-9254dee26bc). 
+
+*Monitor Radio* often featured interviews with political leaders, among them South African activist [Bishop Desmond Tutu](https://americanarchive.org/catalog/cpb-aacip-3dd61430b6e). Additionally, *Monitor Radio Conversations* shared in-depth discussions with an array of public figures, such as writer [Neil Postman](https://americanarchive.org/catalog/cpb-aacip-8fd3944181e), astronomer [Carl Sagan](https://americanarchive.org/catalog/cpb-aacip-239cc1e2140), and filmmakers [Tim Burton](https://americanarchive.org/catalog/cpb-aacip-d8a20832670) and [Ken Burns](https://americanarchive.org/catalog/cpb-aacip-58e9acdca58). Other noteworthy guests on *Monitor Radio Conversations* include [Chuck Yeager](https://americanarchive.org/catalog/cpb-aacip-5323120a924), the first pilot to exceed the speed of sound in flight, and celebrity chef [Julia Child](https://americanarchive.org/catalog/cpb-aacip-6c5019b7a57).
+
+## Background
+
+Monitor Radio was a broadcast service of *The Christian Science Monitor* from 1984 to 1997. Its main program, the magazine series *Monitor Radio*, was preceded by *Monitor News Service,* produced from 1977 to 1983. Although the oldest Monitor items in the AAPB are from the 1970s, *The Christian Science Monitor* was active in news radio as early as the 1920s.
+
+At its height, the Monitor Radio service reached 1.1 million listeners a week and aired on over 200 radio stations. Throughout most of its history, programming was distributed in the US by American Public Radio, which rebranded as Public Radio International in 1994. Monitor Radio programming also aired on shortwave radio in Europe, Asia, and Africa.
+
+Monitor Radio won multiple awards for journalistic excellence, such as first place for radio in the 1991 Robert F. Kennedy Journalism Awards for reporter Peter Kent’s five-part series on the challenges facing Black Americans in the 1990s. Monitor Radio was financially supported by several corporations and philanthropic organizations, including the J.M. Smucker Company and the Ford, Powell, Pew, and MacArthur Foundations. The Monitor Radio special collection was added to the AAPB in August 2026.
+
+## Featured
+
+[![AIDS](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-08bb9719d4c)
+[![Chernobyl](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-fbc75b3c14f)
+[![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-9cf8e5bfd21)
+[![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-882295338b6)
+[![Bosnia](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-35d0786be67)
+[![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-d199684e32a ) 
+
+## Resources
+
+- [The Christian Science Monitor](https://www.csmonitor.com/)
+- [Editor’s Note: Monitor Radio](https://www.csmonitor.com/1997/0627/062797.edit.edit.3.html) (June 27, 1997)
+- [Podcast: Why We Wrote This: Reporting on the Failed Soviet Coup](https://www.csmonitor.com/Podcasts/Why-We-Wrote-This/wwwt_2608) (August 14, 2026)
+- [AAPB Special Collection: War and Peace in the Nuclear Age](https://americanarchive.org/special_collections/wapina) 
+
+
+## Funders
+
+## Help
+
+Records are described at an item level and all records contain brief descriptions and subject terms. Search by keyword or individual, or browse all episodes by clicking "View the Collection" below the search box.
+
+## Terms
+
+## Timeline
+ 
+## Sort
+
+asset_date+asc

--- a/app/views/special_collections/monitor.md
+++ b/app/views/special_collections/monitor.md
@@ -12,7 +12,7 @@ In keeping with *The Christian Science Monitor*’s editorial principles, *Monit
 
 Several episodes reflect on recent history. For example, in 1989, *Monitor Radio* aired a report on the partial meltdown of the [Three Mile Island nuclear plant](https://americanarchive.org/catalog/cpb-aacip-0fd550a4575) in Londonderry Township, Pennsylvania, a decade earlier. Similarly, on the ten-year anniversary of the [Chernobyl nuclear disaster](https://americanarchive.org/catalog/cpb-aacip-292e394e53e) in northern Ukraine, *Monitor Radio* featured a story on the incident and its lasting effects on survivors and the environment. On the fortieth anniversary of the founding of Israel, *Monitor Radio* offered an [objective account](https://americanarchive.org/catalog/cpb-aacip-306da3ceeec) of the history of the country and present-day challenges, and on December 26, 1991, the [program looked back](https://americanarchive.org/catalog/cpb-aacip-9cf8e5bfd21) on the Soviet Union’s final year on the day it was formally dissolved.
 
-*Monitor Radio* not only reported on major news stories; it also explored their complexities. For instance, when [Nelson Mandela was released from prison](https://americanarchive.org/catalog/cpb-aacip-9f46aa1937b) on February 11, 1990, *Monitor Radio* reported on his first public comments following his 27-year imprisonment. It then delved deeper into the topic of the anti-apartheid movement, featuring a story on the impact of US-imposed economic sanctions on South Africa and a profile of Mandela titled “Nelson Mandela: The Man Behind the Myth.”
+*Monitor Radio* went beyond covering major news stories; it also put these stories in context. For instance, when [Nelson Mandela was released from prison](https://americanarchive.org/catalog/cpb-aacip-9f46aa1937b) on February 11, 1990, *Monitor Radio* reported on his first public comments following his 27-year imprisonment. It then delved deeper into the topic of the anti-apartheid movement, featuring a story on the impact of US-imposed economic sanctions on South Africa and a profile of Mandela titled “Nelson Mandela: The Man Behind the Myth.”
 
 In addition to reporting on international issues, *Monitor Radio* also covered US news and politics, such as efforts to pass the [North American Free Trade Agreement](https://americanarchive.org/catalog/cpb-aacip-dd58db9823f), the [Oklahoma City bombing](https://americanarchive.org/catalog/cpb-aacip-1f2d43a501a), and the [O.J. Simpson trial](https://americanarchive.org/catalog/cpb-aacip-2cc808c7c83). The series documented the United States’ [entry into the Gulf War](https://americanarchive.org/catalog/cpb-aacip-6e58c05ba9e), as well as major scientific breakthroughs, including the [launch of the Hubble Space Telescope](https://americanarchive.org/catalog/cpb-aacip-050b385deea) and the [cloning of Dolly the sheep](https://americanarchive.org/catalog/cpb-aacip-9254dee26bc). 
 
@@ -28,12 +28,12 @@ Monitor Radio won multiple awards for journalistic excellence, such as first pla
 
 ## Featured
 
-[![AIDS, Part I](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-08bb9719d4c)
-[![Chernobyl Disaster](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-fbc75b3c14f)
-[![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-9cf8e5bfd21)
-[![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-882295338b6)
-[![Bosnian War](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-35d0786be67)
-[![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-d199684e32a ) 
+[![AIDS, Part I](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-08bb9719d4c)
+[![Chernobyl Disaster](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-fbc75b3c14f)
+[![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-9cf8e5bfd21)
+[![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-882295338b6)
+[![Bosnian War](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-35d0786be67)
+[![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail-2.png)](/catalog/cpb-aacip-d199684e32a ) 
 
 ## Resources
 

--- a/app/views/special_collections/monitor.md
+++ b/app/views/special_collections/monitor.md
@@ -2,7 +2,7 @@
 
 ## Thumbnail
 
-![Monitor Radio logo featuring a globe against a white background and the words "Monitor Radio: A Service of the Christian Science Monitor"](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-thumbnail-upscaled.png "Monitor Radio logo") 
+![Monitor Radio logo featuring a globe against a white background and the words "Monitor Radio: A Service of the Christian Science Monitor"](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-thumbnail-upscaled.jpeg "Monitor Radio logo") 
 
 ## Summary 
 
@@ -28,11 +28,11 @@ Monitor Radio won multiple awards for journalistic excellence, such as first pla
 
 ## Featured
 
-[![AIDS](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-08bb9719d4c)
-[![Chernobyl](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-fbc75b3c14f)
+[![AIDS, Part I](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-08bb9719d4c)
+[![Chernobyl Disaster](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-fbc75b3c14f)
 [![End of the USSR](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-9cf8e5bfd21)
 [![Black Americans](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-882295338b6)
-[![Bosnia](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-35d0786be67)
+[![Bosnian War](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-35d0786be67)
 [![Hong Kong Handover](https://s3.amazonaws.com/americanarchive.org/special-collections/monitor-asset-thumbnail.png)](/catalog/cpb-aacip-d199684e32a ) 
 
 ## Resources


### PR DESCRIPTION
This file introduces the Monitor Radio collection, detailing its history, significance, and notable broadcasts, along with resources and funders related to the collection.