### PR TITLE
Update NCSG55098.md

### DIFF
--- a/app/views/organizations/md/NCSG55098.md
+++ b/app/views/organizations/md/NCSG55098.md
@@ -1,8 +1,8 @@
-# Nashville PBS
+# Nashville Public Television
 
 ## Short name
 
-Nashville Public Television
+Nashville PBS
 
 ## State
 

--- a/public/data/orgs.json
+++ b/public/data/orgs.json
@@ -76,14 +76,14 @@
     "location": [39.4737328, -74.5212157]
   },
   "NCSG55098": {
-    "Short name": "Nashville Public Television",
+    "Short name": "Nashville PBS",
     "State": "Tennessee",
     "City": "Nashville",
     "Logo": "npt_logo.png",
     "Url": "https://www.wnpt.org/",
     "About": "Nashville Public Television, Nashville's PBS station, is available free and over-the-air to nearly 2.4 million people throughout the Middle Tennessee and southern Kentucky viewing area. NPT's three broadcast channels are NPT, the main channel; secondary channel NPT2; and NPT3, a 24/7 PBS Kids channel. NPT is also available to anyone in the world through its array of NPT digital services, including wnpt.org, YouTube channels and the PBS video app. NPT provides, through the power of traditional television and interactive digital communications, quality educational, cultural and civic experiences that address issues and concerns of the people of the Nashville region, and which thereby help improve the lives of those we serve. \nWNPT, Nashville's independent nonprofit PBS station, is operated by licensee Nashville Public Television, Inc.",
     "Productions": "",
-    "Name": "Nashville PBS",
+    "Name": "Nashville Public Television",
     "location": [36.134955, -86.7653169]
   },
   "4721": {


### PR DESCRIPTION
fixing the mixed up short name versus top name! short name now changed to Nashville PBS, top name reverted to Nashville Public Television